### PR TITLE
repaired Javadoc

### DIFF
--- a/server-api/src/main/java/org/jboss/aerogear/simplepush/server/SimplePushServer.java
+++ b/server-api/src/main/java/org/jboss/aerogear/simplepush/server/SimplePushServer.java
@@ -44,8 +44,8 @@ public interface SimplePushServer {
 
     /**
      * Handles the 'register' message in the SimplePush protocol which is used to register a channel.
-     *
-     * @param registerMessage the {@link RegisterMessage}.
+     * 
+     * @param register the {@link RegisterMessage}.
      * @param uaid the UserAgent identifier that this channel will be registered for.
      * @return {@link RegisterResponse} the response for this register message.
      */

--- a/server-api/src/main/java/org/jboss/aerogear/simplepush/server/datastore/DataStore.java
+++ b/server-api/src/main/java/org/jboss/aerogear/simplepush/server/datastore/DataStore.java
@@ -82,7 +82,7 @@ public interface DataStore {
      *
      * @param update the {@link Update} to remove.
      * @param uaid the {@link String} of the UserAgent
-     * @return
+     * @return true if the {@code update} is removed, false otherwise
      */
     boolean removeUpdate(Update update, String uaid);
 }


### PR DESCRIPTION
I was generating Javadoc like `mvn clean javadoc:aggregate` and there were warnings regarding missing things. Generation of Javadocs are now totally without issues.

Anyway I would like to add GraphViz into it like it is done with ShrinkWrap API, that would be super cool

https://docs.jboss.org/shrinkwrap/1.0.0-cr-3/
