### PR TITLE
added Graphviz Javadoc generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,14 @@ A WildFly/AS7 module for the SimplePush Server.
 
 Please refer to the above modules documentation for more information.
 
+#### How to generate Javadocs?
+
+Your Javadocs are generated while building the project itself. Execute in the root dir:
+
+```mvn clean install```
+
+When you want them to be aggregated (meaning all docs in one, not by modules), please execute the following command after the first one:
+
+```mvn javadoc:aggregate```
+
+When you have [GraphViz](https://code.google.com/p/apiviz/) installed locally on your host, your Javadocs will be enriched by class model embedded directly into them as images. They are placed in ```target/site/apidocs```

--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,13 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
+    <!-- Model version -->
     <modelVersion>4.0.0</modelVersion>
+
+    <!-- Artifact configuration -->
     <artifactId>simplepush-server-parent</artifactId>
     <packaging>pom</packaging>
     <version>0.9.0-SNAPSHOT</version>
@@ -28,18 +32,21 @@
         A SimplePush Server Implementation.
     </description>
 
+    <!-- Parent -->
     <parent>
         <groupId>org.jboss.aerogear</groupId>
         <artifactId>aerogear-parent</artifactId>
         <version>0.1.0</version>
     </parent>
 
+    <!-- Properties -->
     <properties>
         <version.io.netty>4.0.5.Final-SNAPSHOT</version.io.netty>
         <version.jackson>1.9.2</version.jackson>
         <version.commons.codec>1.8</version.commons.codec>
     </properties>
 
+    <!-- Modules -->
     <modules>
         <module>protocol</module>
         <module>server-api</module>
@@ -49,6 +56,7 @@
         <module>wildfly-module</module>
     </modules>
 
+    <!-- Dependency Management -->
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -112,6 +120,7 @@
         </dependencies>
     </dependencyManagement>
 
+    <!-- Build -->
     <build>
         <plugins>
             <plugin>
@@ -133,13 +142,51 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9</version>
                 <configuration>
+                    <doclet>org.jboss.apiviz.APIviz</doclet>
+                    <docletArtifact>
+                        <groupId>org.jboss.apiviz</groupId>
+                        <artifactId>apiviz</artifactId>
+                        <version>1.3.2.GA</version>
+                    </docletArtifact>
                     <detectOfflineLinks>false</detectOfflineLinks>
+                    <useStandardDocletOptions>true</useStandardDocletOptions>
+                    <bootclasspath>${sun.boot.class.path}</bootclasspath>
+                    <charset>UTF-8</charset>
+                    <encoding>UTF-8</encoding>
+                    <docencoding>UTF-8</docencoding>
                     <breakiterator>true</breakiterator>
                     <version>false</version>
                     <author>false</author>
                     <keywords>true</keywords>
+                    <linksource>false</linksource>
                     <quiet>true</quiet>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-sources</id>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <tasks>
+                                <mkdir dir="target/classes" />
+                                <mkdir dir="target/test-classes" />
+                            </tasks>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
@@ -205,6 +252,19 @@
                                         <execute>
                                             <runOnIncremental>false</runOnIncremental>
                                         </execute>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-antrun-plugin</artifactId>
+                                        <versionRange>[1.0.0,)</versionRange>
+                                        <goals>
+                                            <goal>run</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore />
                                     </action>
                                 </pluginExecution>
                             </pluginExecutions>


### PR DESCRIPTION
Javadocs now looks like this http://miklosovic.net/apidocs/ or e.g. like this: http://miklosovic.net/apidocs/org/jboss/aerogear/simplepush/protocol/MessageType.html

README.md reflects changes, ignore action for ant run prevents marking this project as errorneous after importing it into Eclipse.
