### PR TITLE
Cleaning up unused channels upon hello message.

### DIFF
--- a/server-api/src/main/java/org/jboss/aerogear/simplepush/server/datastore/DataStore.java
+++ b/server-api/src/main/java/org/jboss/aerogear/simplepush/server/datastore/DataStore.java
@@ -60,6 +60,23 @@ public interface DataStore {
     void removeChannels(String uaid);
 
     /**
+     * Removes all channels matching the set passed in.
+     *
+     * @param channelIds the ids of the channels to be removed.
+     * @param {@code Integer} the number of entries removed.
+     */
+    Integer removeChannels(Set<String> channelIds);
+
+    /**
+     * Returns registered channel ids for a certain UserAgent Identifier (uaid)
+     *
+     * @param uaid the UserAgent Identifier for which all channels that belongs to
+     *        that id should be removed.
+     * @return {@code Set<String>} the registered channels.
+     */
+    Set<String> getChannelIds(String uaid);
+
+    /**
      * Stores {@code updates/channelIds} so that the notification can be matched against
      * acknowledged channelId from the UserAgent.
      *

--- a/server-core/src/main/java/org/jboss/aerogear/simplepush/server/DefaultSimplePushConfig.java
+++ b/server-core/src/main/java/org/jboss/aerogear/simplepush/server/DefaultSimplePushConfig.java
@@ -16,7 +16,6 @@
  */
 package org.jboss.aerogear.simplepush.server;
 
-import org.jboss.aerogear.simplepush.util.CryptoUtil;
 
 /**
  * Configuration settings for SimplePush server

--- a/server-core/src/main/java/org/jboss/aerogear/simplepush/server/DefaultSimplePushServer.java
+++ b/server-core/src/main/java/org/jboss/aerogear/simplepush/server/DefaultSimplePushServer.java
@@ -63,9 +63,15 @@ public class DefaultSimplePushServer implements SimplePushServer {
 
     @Override
     public HelloResponse handleHandshake(final HelloMessage handshake) {
+        final Set<String> oldChannels = store.getChannelIds(handshake.getUAID());
         for (String channelId : handshake.getChannelIds()) {
-            store.saveChannel(new DefaultChannel(handshake.getUAID(), channelId, makeEndpointUrl(handshake.getUAID(), channelId)));
+            if (!oldChannels.contains(channelId)) {
+                store.saveChannel(new DefaultChannel(handshake.getUAID(), channelId, makeEndpointUrl(handshake.getUAID(), channelId)));
+            } else {
+                oldChannels.remove(channelId);
+            }
         }
+        store.removeChannels(oldChannels);
         return new HelloResponseImpl(handshake.getUAID());
     }
 

--- a/server-core/src/main/java/org/jboss/aerogear/simplepush/server/datastore/InMemoryDataStore.java
+++ b/server-core/src/main/java/org/jboss/aerogear/simplepush/server/datastore/InMemoryDataStore.java
@@ -19,6 +19,7 @@ package org.jboss.aerogear.simplepush.server.datastore;
 import static org.jboss.aerogear.simplepush.util.ArgumentUtil.checkNotNull;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -72,6 +73,30 @@ public class InMemoryDataStore implements DataStore {
             }
         }
         notifiedChannels.remove(uaid);
+    }
+
+    @Override
+    public Integer removeChannels(final Set<String> channelIds) {
+        checkNotNull(channelIds, "channelIds");
+        int removed = 0;
+        for (String channelId : channelIds) {
+            channels.remove(channelId);
+            removed++;
+            logger.debug("Removing [" + channelId + "]");
+        }
+        return removed;
+    }
+
+    @Override
+    public Set<String> getChannelIds(final String uaid) {
+        checkNotNull(uaid, "uaid");
+        final Set<String> channelIds = new HashSet<String>();
+        for (Channel channel : channels.values()) {
+            if (channel.getUAID().equals(uaid)) {
+                channelIds.add(channel.getChannelId());
+            }
+        }
+        return channelIds;
     }
 
     @Override

--- a/server-core/src/main/java/org/jboss/aerogear/simplepush/server/datastore/JpaDataStore.java
+++ b/server-core/src/main/java/org/jboss/aerogear/simplepush/server/datastore/JpaDataStore.java
@@ -108,6 +108,35 @@ public final class JpaDataStore implements DataStore {
     }
 
     @Override
+    public Integer removeChannels(final Set<String> channelIds) {
+        final JpaOperation<Integer> removeChannel = new JpaOperation<Integer>() {
+            @Override
+            public Integer perform(EntityManager em) {
+                final Query delete = em.createQuery("DELETE from ChannelDTO c where c.channelId in (:channelIds)");
+                delete.setParameter("channelIds", channelIds);
+                return delete.executeUpdate();
+            }
+        };
+        return jpaExecutor.execute(removeChannel);
+    }
+
+    @Override
+    public Set<String> getChannelIds(final String uaid) {
+        final JpaOperation<Set<String>> getChannelIds = new JpaOperation<Set<String>>() {
+            @Override
+            public Set<String> perform(final EntityManager em) {
+                final Set<String> channels = new HashSet<String>();
+                final UserAgentDTO ua = em.find(UserAgentDTO.class, uaid);
+                for (ChannelDTO dto : ua.getChannels()) {
+                    channels.add(dto.getChannelId());
+                }
+                return channels;
+            }
+        };
+        return jpaExecutor.execute(getChannelIds);
+    }
+
+    @Override
     public void removeChannels(final String uaid) {
         final JpaOperation<Void> removeChannels = new JpaOperation<Void>() {
             @Override

--- a/server-core/src/test/java/org/jboss/aerogear/simplepush/server/DefaultSimplePushServerTest.java
+++ b/server-core/src/test/java/org/jboss/aerogear/simplepush/server/DefaultSimplePushServerTest.java
@@ -64,7 +64,8 @@ public class DefaultSimplePushServerTest {
         final HelloMessage handshakeImpl = new HelloMessageImpl(UUIDUtil.newUAID().toString(), channelIds);
         final HelloResponse response = server.handleHandshake(handshakeImpl);
         assertThat(response.getUAID(), is(notNullValue()));
-        assertThat(server.getChannel("channel1").getChannelId(), is(equalTo("channel1")));
+        assertThat(server.getChannel("channel1"), is(notNullValue()));
+        assertThat(server.getChannel("channel2"), is(notNullValue()));
     }
 
     @Test
@@ -74,6 +75,43 @@ public class DefaultSimplePushServerTest {
         final HelloResponse response = server.handleHandshake(handshakeImpl);
         assertThat(response.getUAID(), is(notNullValue()));
         assertThat(server.hasChannel("channel1"), is(false));
+    }
+
+    @Test
+    public void handleHandshakeWithExistingAndEmptyChannelIDsInHello() throws ChannelNotFoundException {
+        final Set<String> channelIds = new HashSet<String>(Arrays.asList("channel1", "channel2"));
+        final String uaid = UUIDUtil.newUAID();
+        final HelloMessage firstHello = new HelloMessageImpl(uaid, channelIds);
+        final HelloResponse firstResponse = server.handleHandshake(firstHello);
+        assertThat(firstResponse.getUAID(), equalTo(uaid));
+        assertThat(server.hasChannel("channel1"), is(true));
+        assertThat(server.hasChannel("channel2"), is(true));
+
+        final HelloMessage nextHello = new HelloMessageImpl(uaid, Collections.<String>emptySet());
+        final HelloResponse secondResponse = server.handleHandshake(nextHello);
+        assertThat(secondResponse.getUAID(), equalTo(uaid));
+        assertThat(server.hasChannel("channel1"), is(false));
+        assertThat(server.hasChannel("channel2"), is(false));
+    }
+
+    @Test
+    public void handleHandshakeWithExistingAndNewChannels() throws ChannelNotFoundException {
+        final Set<String> channelIds = new HashSet<String>(Arrays.asList("channel1", "channel2"));
+        final String uaid = UUIDUtil.newUAID();
+        final HelloMessage firstHello = new HelloMessageImpl(uaid, channelIds);
+        final HelloResponse firstResponse = server.handleHandshake(firstHello);
+        assertThat(firstResponse.getUAID(), equalTo(uaid));
+        assertThat(server.hasChannel("channel1"), is(true));
+        assertThat(server.hasChannel("channel2"), is(true));
+
+        final Set<String> newChannelIds = new HashSet<String>(Arrays.asList("channel3", "channel4"));
+        final HelloMessage nextHello = new HelloMessageImpl(uaid, newChannelIds);
+        final HelloResponse secondResponse = server.handleHandshake(nextHello);
+        assertThat(secondResponse.getUAID(), equalTo(uaid));
+        assertThat(server.hasChannel("channel1"), is(false));
+        assertThat(server.hasChannel("channel2"), is(false));
+        assertThat(server.hasChannel("channel3"), is(true));
+        assertThat(server.hasChannel("channel4"), is(true));
     }
 
     @Test

--- a/server-core/src/test/java/org/jboss/aerogear/simplepush/server/datastore/InMemoryDataStoreTest.java
+++ b/server-core/src/test/java/org/jboss/aerogear/simplepush/server/datastore/InMemoryDataStoreTest.java
@@ -57,6 +57,19 @@ public class InMemoryDataStoreTest {
     }
 
     @Test
+    public void getChannels() throws ChannelNotFoundException {
+        final InMemoryDataStore store = new InMemoryDataStore();
+        final String uaid = UUIDUtil.newUAID();
+        final String channelId1 = UUID.randomUUID().toString();
+        final String channelId2 = UUID.randomUUID().toString();
+        store.saveChannel(new DefaultChannel(uaid, channelId1, "endpoint/" + channelId1));
+        store.saveChannel(new DefaultChannel(uaid, channelId2, "endpoint/" + channelId2));
+        final Set<String> channels = store.getChannelIds(uaid);
+        assertThat(channels.size(), is(2));
+        assertThat(channels, hasItems(channelId1, channelId2));
+    }
+
+    @Test
     public void removeChannel() {
         final InMemoryDataStore store = new InMemoryDataStore();
         store.saveChannel(new DefaultChannel(UUIDUtil.newUAID(), "channel-1", "endpoint/1"));

--- a/server-core/src/test/java/org/jboss/aerogear/simplepush/server/datastore/JpaDataStoreTest.java
+++ b/server-core/src/test/java/org/jboss/aerogear/simplepush/server/datastore/JpaDataStoreTest.java
@@ -18,6 +18,7 @@ package org.jboss.aerogear.simplepush.server.datastore;
 
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -68,6 +69,18 @@ public class JpaDataStoreTest {
         assertThat(channel.getUAID(), equalTo(uaid));
         assertThat(channel.getVersion(), equalTo(10L));
         assertThat(channel.getPushEndpoint(), equalTo("/endpoint/" + channelId));
+    }
+
+    @Test
+    public void getChannels() throws ChannelNotFoundException {
+        final String uaid = UUIDUtil.newUAID();
+        final String channelId1 = UUID.randomUUID().toString();
+        final String channelId2 = UUID.randomUUID().toString();
+        jpaDataStore.saveChannel(newChannel(uaid, channelId1, 10L));
+        jpaDataStore.saveChannel(newChannel(uaid, channelId2, 10L));
+        final Set<String> channels = jpaDataStore.getChannelIds(uaid);
+        assertThat(channels.size(), is(2));
+        assertThat(channels, hasItems(channelId1, channelId2));
     }
 
     @Test (expected = ChannelNotFoundException.class)


### PR DESCRIPTION
The hello message in the SimplePush protocol may contain an array of
channelIDs, which are channels that the client knows about. These
channels should be registered but there might be old channels that are
no longer in use which can be cleaned up. This commit does that cleaning
up.
