### PR TITLE
Making sure that private key creation is only done one.

### DIFF
--- a/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/SimplePushServiceFactory.java
+++ b/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/SimplePushServiceFactory.java
@@ -21,6 +21,7 @@ import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsConfig;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsService;
 
 import org.jboss.aerogear.simplepush.server.DefaultSimplePushServer;
+import org.jboss.aerogear.simplepush.server.SimplePushServer;
 import org.jboss.aerogear.simplepush.server.SimplePushServerConfig;
 import org.jboss.aerogear.simplepush.server.datastore.DataStore;
 
@@ -29,27 +30,22 @@ import org.jboss.aerogear.simplepush.server.datastore.DataStore;
  */
 public class SimplePushServiceFactory extends AbstractSockJsServiceFactory {
 
-    private final DataStore datastore;
-    private final SimplePushServerConfig simplePushConfig;
+    private final SimplePushServer simplePushServer;
 
     /**
      * Sole constructor.
      *
      * @param sockjsConfig the Netty SockJS configuration.
-     * @param datastore the {@link DataStore} to be used by all instances created.
-     * @param simplePushConfig the {@link SimplePushServerConfig} configuration.
+     * @param simplePushServer the {@link SimplePushServer} to be used by all instances created.
      */
-    public SimplePushServiceFactory(final SockJsConfig sockjsConfig, final DataStore datastore,
-            final SimplePushServerConfig simplePushConfig) {
+    public SimplePushServiceFactory(final SockJsConfig sockjsConfig, final SimplePushServer simplePushServer) {
         super(sockjsConfig);
-        this.datastore = datastore;
-        this.simplePushConfig = simplePushConfig;
+        this.simplePushServer = simplePushServer;
     }
 
     @Override
     public SockJsService create() {
-        final byte[] privateKey = DefaultSimplePushServer.generateAndStorePrivateKey(datastore, simplePushConfig);
-        return new SimplePushSockJSService(config(), new DefaultSimplePushServer(datastore, simplePushConfig, privateKey));
+        return new SimplePushSockJSService(config(), simplePushServer);
     }
 
 }

--- a/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/SimplePushSockJSService.java
+++ b/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/SimplePushSockJSService.java
@@ -63,7 +63,7 @@ public class SimplePushSockJSService implements SockJsService {
     /**
      * Sole constructor.
      *
-     * @param sockjsConfig the SockJS {@link Config} for this service.
+     * @param sockjsConfig the SockJS {@link SockJsConfig} for this service.
      * @param simplePushServer the {@link SimplePushServer} that this instance will use.
      */
     public SimplePushSockJSService(final SockJsConfig sockjsConfig, final SimplePushServer simplePushServer) {

--- a/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/SockJSChannelInitializer.java
+++ b/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/SockJSChannelInitializer.java
@@ -85,7 +85,7 @@ public class SockJSChannelInitializer extends ChannelInitializer<SocketChannel> 
         final DefaultSimplePushServer simplePushServer = new DefaultSimplePushServer(datastore, simplePushConfig, privateKey);
         pipeline.addLast(new NotificationHandler(simplePushServer));
         pipeline.addLast(new CorsInboundHandler());
-        pipeline.addLast(new SockJsHandler(new SimplePushServiceFactory(sockjsConfig, datastore, simplePushConfig)));
+        pipeline.addLast(new SockJsHandler(new SimplePushServiceFactory(sockjsConfig, simplePushServer)));
         pipeline.addLast(backgroundGroup, new UserAgentReaperHandler(simplePushServer));
         pipeline.addLast(new CorsOutboundHandler());
     }


### PR DESCRIPTION
- This was being done for every invocation which was very inefficient.
- Also two instance of the DefaultSimplePushServer were created which has now been fixed.
