### PR TITLE
AGSMPLPUSH-42 "xhr_streaming/xhr_polling protocols are not working"

### DIFF
--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/SockJsSessionContext.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/SockJsSessionContext.java
@@ -38,5 +38,10 @@ public interface SockJsSessionContext {
     /**
      * Get the underlying ChannelHandlerContext.
      */
-    ChannelHandlerContext getContext();
+    ChannelHandlerContext getConnectionContext();
+
+    /**
+     * Get the underlying ChannelHandlerContext.
+     */
+    ChannelHandlerContext getCurrentContext();
 }

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/AbstractTimersSessionState.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/AbstractTimersSessionState.java
@@ -61,7 +61,7 @@ abstract class AbstractTimersSessionState implements SessionState {
                     }
                     if (session.timestamp() + session.config().sessionTimeout() < now) {
                         final SockJsSession removed = sessions.remove(session.sessionId());
-                        session.context().close();
+                        session.connectionContext().close();
                         sessionTimer.cancel(true);
                         heartbeatFuture.cancel(true);
                         if (logger.isDebugEnabled()) {

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/JsonpPollingSessionState.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/JsonpPollingSessionState.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.jboss.aerogear.io.netty.handler.codec.sockjs.handler;
+
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpRequest;
+import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsConfig;
+import org.jboss.aerogear.io.netty.handler.codec.sockjs.protocol.HeartbeatFrame;
+
+import java.util.concurrent.ConcurrentMap;
+
+class JsonpPollingSessionState extends PollingSessionState {
+
+    public JsonpPollingSessionState(ConcurrentMap<String, SockJsSession> sessions, HttpRequest request, SockJsConfig config) {
+        super(sessions, request, config);
+    }
+
+    @Override
+    public void sendNoMessagesResponse(final HttpRequest request, final SockJsConfig config, final ChannelHandlerContext ctx) {
+        ctx.writeAndFlush(new HeartbeatFrame()).addListener(ChannelFutureListener.CLOSE);
+    }
+
+}

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/PollingSessionState.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/PollingSessionState.java
@@ -18,12 +18,15 @@ package org.jboss.aerogear.io.netty.handler.codec.sockjs.handler;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.*;
+import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsConfig;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.protocol.MessageFrame;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.concurrent.ConcurrentMap;
+
 
 /**
  * A polling state does not have a persistent connection to the client, instead a client
@@ -40,27 +43,50 @@ import java.util.concurrent.ConcurrentMap;
  * in the response.
  *
  */
-class PollingSessionState extends AbstractTimersSessionState {
+abstract class PollingSessionState extends AbstractTimersSessionState {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(PollingSessionState.class);
     private final ConcurrentMap<String, SockJsSession> sessions;
+    private final HttpRequest request;
+    private final SockJsConfig config;
 
-    public PollingSessionState(final ConcurrentMap<String, SockJsSession> sessions) {
+    public PollingSessionState(final ConcurrentMap<String, SockJsSession> sessions,
+                               final HttpRequest request,
+                               final SockJsConfig config) {
         super(sessions);
         this.sessions = sessions;
+        this.request = request;
+        this.config = config;
     }
+
+    /**
+     * Gives implementations the ability to decide what a response should look like and
+     * also how it should be written back to the client.
+     *
+     * @param request the polling HttpRequest.
+     * @param config the SockJsConfig.
+     * @param ctx {@code ChannelHandlerContext} the context.
+     */
+    public abstract void sendNoMessagesResponse(HttpRequest request, SockJsConfig config, ChannelHandlerContext ctx);
 
     @Override
     public void onOpen(final SockJsSession session, final ChannelHandlerContext ctx) {
         flushMessages(ctx, session);
     }
 
-    private static void flushMessages(final ChannelHandlerContext ctx, final SockJsSession session) {
+    @Override
+    public ChannelHandlerContext getSendingContext(SockJsSession session) {
+        return session.connectionContext();
+    }
+
+    private void flushMessages(final ChannelHandlerContext ctx, final SockJsSession session) {
         final String[] allMessages = session.getAllMessages();
         if (allMessages.length == 0) {
+            sendNoMessagesResponse(request, config, ctx);
             return;
         }
         final MessageFrame messageFrame = new MessageFrame(allMessages);
-        ctx.channel().writeAndFlush(messageFrame).addListener(new ChannelFutureListener() {
+        ChannelFuture channelFuture = ctx.channel().writeAndFlush(messageFrame);
+        channelFuture.addListener(new ChannelFutureListener() {
             @Override
             public void operationComplete(final ChannelFuture future) throws Exception {
                 if (!future.isSuccess()) {
@@ -68,19 +94,20 @@ class PollingSessionState extends AbstractTimersSessionState {
                 }
             }
         });
+        channelFuture.addListener(ChannelFutureListener.CLOSE);
     }
 
     @Override
     public boolean isInUse(final SockJsSession session) {
-        return session.context().channel().isActive() || session.inuse();
+        return session.connectionContext().channel().isActive() || session.inuse();
     }
 
     @Override
     public void onSockJSServerInitiatedClose(final SockJsSession session) {
-        final ChannelHandlerContext context = session.context();
+        final ChannelHandlerContext context = session.connectionContext();
         if (context != null) { //could be null if the request is aborted, for example due to missing callback.
             if (logger.isDebugEnabled()) {
-                logger.debug("Will close session context {}", session.context());
+                logger.debug("Will close session connectionContext {}", session.connectionContext());
             }
             context.close();
         }

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SendingSessionState.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SendingSessionState.java
@@ -47,11 +47,16 @@ class SendingSessionState implements SessionState {
     }
 
     @Override
+    public ChannelHandlerContext getSendingContext(SockJsSession session) {
+        return session.currentContext();
+    }
+
+    @Override
     public void onSockJSServerInitiatedClose(final SockJsSession session) {
         if (logger.isDebugEnabled()) {
-            logger.debug("Will close session context {}", session.context());
+            logger.debug("Will close session connectionContext {}", session.connectionContext());
         }
-        session.context().close();
+        session.connectionContext().close();
         sessions.remove(session.sessionId());
     }
 

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SessionState.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SessionState.java
@@ -46,6 +46,16 @@ interface SessionState {
     void onOpen(SockJsSession session, ChannelHandlerContext ctx);
 
     /**
+     * Returns the ChannelHandlerContext that should be used to communicate with the client.
+     * This may be different for different transports. For some transports this will be the
+     * context that opened the connection and others it will be the current context.
+     *
+     * @param session the {@link SockJsSession}.
+     * @return {@code ChannelHandlerContext} the context to be used for sending.
+     */
+    ChannelHandlerContext getSendingContext(SockJsSession session);
+
+    /**
      * Called after the {@link SockJsSession#onClose()} method has been called enabling
      * this SessionState to perform any clean up actions requried.
      */

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SockJsHandler.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SockJsHandler.java
@@ -128,11 +128,11 @@ public class SockJsHandler extends SimpleChannelInboundHandler<FullHttpRequest> 
         switch (pathParams.transport()) {
         case XHR:
             addTransportHandler(new XhrPollingTransport(factory.config(), request), ctx);
-            addSessionHandler(new PollingSessionState(sessions), getSession(factory, pathParams.sessionId()), ctx);
+            addSessionHandler(new XhrPollingSessionState(sessions, request, factory.config()), getSession(factory, pathParams.sessionId()), ctx);
             break;
         case JSONP:
             addTransportHandler(new JsonpPollingTransport(factory.config(), request), ctx);
-            addSessionHandler(new PollingSessionState(sessions), getSession(factory, pathParams.sessionId()), ctx);
+            addSessionHandler(new JsonpPollingSessionState(sessions, request, factory.config()), getSession(factory, pathParams.sessionId()), ctx);
             break;
         case XHR_SEND:
             checkSessionExists(pathParams.sessionId(), request);

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SockJsSession.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SockJsSession.java
@@ -36,21 +36,28 @@ class SockJsSession {
     private final LinkedList<String> messages = new LinkedList<String>();
     private final AtomicLong timestamp = new AtomicLong();
     private final AtomicBoolean inuse = new AtomicBoolean();
-    private ChannelHandlerContext ctx;
+    private ChannelHandlerContext connectionContext;
+    private ChannelHandlerContext currentContext;
 
     public SockJsSession(final String sessionId, final SockJsService service) {
         this.sessionId = sessionId;
         this.service = service;
     }
 
-    public synchronized ChannelHandlerContext context() {
-        return ctx;
+    public synchronized ChannelHandlerContext connectionContext() {
+        return connectionContext;
     }
 
-    public synchronized void setContext(final ChannelHandlerContext ctx) {
-        if (this.ctx == null) {
-            this.ctx = ctx;
-        }
+    public synchronized void setConnectionContext(final ChannelHandlerContext ctx) {
+        connectionContext = ctx;
+    }
+
+    public synchronized ChannelHandlerContext currentContext() {
+        return currentContext;
+    }
+
+    public synchronized void setCurrentContext(final ChannelHandlerContext ctx) {
+        currentContext = ctx;
     }
 
     public synchronized void setState(States state) {

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/StreamingSessionState.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/StreamingSessionState.java
@@ -48,8 +48,13 @@ class StreamingSessionState extends AbstractTimersSessionState {
         flushMessages(ctx, session);
     }
 
+    @Override
+    public ChannelHandlerContext getSendingContext(SockJsSession session) {
+        return session.connectionContext();
+    }
+
     private static void flushMessages(final ChannelHandlerContext ignored, final SockJsSession session) {
-        final Channel channel = session.context().channel();
+        final Channel channel = session.connectionContext().channel();
         if (channel.isActive() && channel.isRegistered()) {
             final String[] allMessages = session.getAllMessages();
             if (allMessages.length == 0) {
@@ -71,16 +76,16 @@ class StreamingSessionState extends AbstractTimersSessionState {
 
     @Override
     public void onSockJSServerInitiatedClose(final SockJsSession session) {
-        final ChannelHandlerContext context = session.context();
+        final ChannelHandlerContext context = session.connectionContext();
         if (context != null) { //could be null if the request is aborted, for example due to missing callback.
-            logger.debug("Will close session context " + session.context());
+            logger.debug("Will close session connectionContext " + session.connectionContext());
             context.close();
         }
     }
 
     @Override
     public boolean isInUse(final SockJsSession session) {
-        return session.context().channel().isActive();
+        return session.connectionContext().channel().isActive();
     }
 
     @Override

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/WebSocketSessionState.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/WebSocketSessionState.java
@@ -65,8 +65,13 @@ class WebSocketSessionState implements SessionState {
     }
 
     @Override
+    public ChannelHandlerContext getSendingContext(SockJsSession session) {
+        return session.connectionContext();
+    }
+
+    @Override
     public boolean isInUse(final SockJsSession session) {
-        return session.context().channel().isActive();
+        return session.connectionContext().channel().isActive();
     }
 
     @Override

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/XhrPollingSessionState.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/XhrPollingSessionState.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.jboss.aerogear.io.netty.handler.codec.sockjs.handler;
+
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpRequest;
+import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsConfig;
+
+import java.util.concurrent.ConcurrentMap;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static org.jboss.aerogear.io.netty.handler.codec.sockjs.transport.Transports.setDefaultHeaders;
+
+class XhrPollingSessionState extends PollingSessionState {
+
+    public XhrPollingSessionState(ConcurrentMap<String, SockJsSession> sessions, HttpRequest request, SockJsConfig config) {
+        super(sessions, request, config);
+    }
+
+    @Override
+    public void sendNoMessagesResponse(final HttpRequest request, final SockJsConfig config, final ChannelHandlerContext ctx) {
+        final DefaultFullHttpResponse response = new DefaultFullHttpResponse(request.getProtocolVersion(), OK);
+        setDefaultHeaders(response, config);
+        if (ctx.channel().isActive() && ctx.channel().isRegistered()) {
+            ctx.channel().writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+
+}

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/transport/JsonpPollingTransport.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/transport/JsonpPollingTransport.java
@@ -15,12 +15,6 @@
  */
 package org.jboss.aerogear.io.netty.handler.codec.sockjs.transport;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH;
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
-import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
-import static io.netty.handler.codec.http.HttpResponseStatus.OK;
-import static io.netty.util.CharsetUtil.UTF_8;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerAdapter;
@@ -34,12 +28,16 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.util.ReferenceCountUtil;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsConfig;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.handler.SessionHandler.Events;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.protocol.Frame;
-import io.netty.util.ReferenceCountUtil;
 
 import java.util.List;
+
+import static io.netty.handler.codec.http.HttpHeaders.Names.*;
+import static io.netty.handler.codec.http.HttpResponseStatus.*;
+import static io.netty.util.CharsetUtil.*;
 
 /**
  * JSON Padding (JSONP) Polling is a transport where there is no open connection between

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/transport/RawWebSocketTransport.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/transport/RawWebSocketTransport.java
@@ -129,7 +129,11 @@ public class RawWebSocketTransport extends SimpleChannelInboundHandler<Object> {
                                 ctx.close();
                             }
                             @Override
-                            public ChannelHandlerContext getContext() {
+                            public ChannelHandlerContext getConnectionContext() {
+                                return ctx;
+                            }
+                            @Override
+                            public ChannelHandlerContext getCurrentContext() {
                                 return ctx;
                             }
                         });

--- a/netty-codec-sockjs/src/test/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/XhrPollingSessionStateTest.java
+++ b/netty-codec-sockjs/src/test/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/XhrPollingSessionStateTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.jboss.aerogear.io.netty.handler.codec.sockjs.handler;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.*;
+import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsConfig;
+import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsService;
+import org.junit.Test;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.mockito.Mockito.*;
+
+public class XhrPollingSessionStateTest {
+
+    @Test
+    public void flushMessagedRepsondNoContent() {
+        final EmbeddedChannel channel = new EmbeddedChannel();
+        final PollingSessionState pollingSessionState = createPollingSessionState();
+        final ChannelHandlerContext ctx = contextForChannel(channel);
+        final SockJsSession sockJsSession = new SockJsSession("1234", mock(SockJsService.class));
+        pollingSessionState.onOpen(sockJsSession, ctx);
+        final HttpResponse response = channel.readOutbound();
+        assertThat(response.getStatus(), is(OK));
+    }
+
+    private PollingSessionState createPollingSessionState() {
+        final ConcurrentMap<String, SockJsSession> sessions = new ConcurrentHashMap<String, SockJsSession>();
+        final HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/123/456/xhr");
+        final SockJsConfig config = SockJsConfig.withPrefix("serviceName").build();
+        final PollingSessionState pollingSessionState = new XhrPollingSessionState(sessions, request, config);
+        return pollingSessionState;
+    }
+
+    private ChannelHandlerContext contextForChannel(final EmbeddedChannel ch) {
+        final ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(ctx.channel()).thenReturn(ch);
+        return ctx;
+    }
+
+}

--- a/netty-codec-sockjs/src/test/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/protocol/SockJsProtocolTest.java
+++ b/netty-codec-sockjs/src/test/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/protocol/SockJsProtocolTest.java
@@ -1070,6 +1070,25 @@ public class SockJsProtocolTest {
         verifyNotCached(pollResponse);
     }
 
+    @Test
+    public void jsonpPollingNoData() throws Exception {
+        final String serviceName = "/echo";
+        final String sessionUrl = serviceName + "/222/" + UUID.randomUUID().toString();
+        final SockJsServiceFactory echoService = echoService();
+
+        final FullHttpResponse openResponse = jsonpRequest(sessionUrl + "/jsonp?c=%63allback", echoService);
+        assertThat(openResponse.getStatus(), is(HttpResponseStatus.OK));
+        assertThat(openResponse.content().toString(UTF_8), equalTo("callback(\"o\");\r\n"));
+        assertThat(openResponse.headers().get(CONTENT_TYPE), equalTo(Transports.CONTENT_TYPE_JAVASCRIPT));
+        verifyNotCached(openResponse);
+
+        final FullHttpResponse pollResponse = jsonpRequest(sessionUrl + "/jsonp?c=callback", echoService);
+        assertThat(pollResponse.getStatus(), is(HttpResponseStatus.OK));
+        assertThat(pollResponse.headers().get(CONTENT_TYPE), equalTo(Transports.CONTENT_TYPE_JAVASCRIPT));
+        assertThat(pollResponse.content().toString(UTF_8), equalTo("callback(\"h\");\r\n"));
+        verifyNotCached(pollResponse);
+    }
+
     /*
      * Equivalent to JsonPolling.test_no_callback in sockjs-protocol-0.3.3.py.
      */

--- a/netty-codec-sockjs/src/test/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/transport/WebSocketTransportTest.java
+++ b/netty-codec-sockjs/src/test/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/transport/WebSocketTransportTest.java
@@ -27,7 +27,6 @@ import static io.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static org.jboss.aerogear.io.netty.handler.codec.sockjs.util.ChannelUtil.webSocketChannel;
 import static org.jboss.aerogear.io.netty.handler.codec.sockjs.util.HttpUtil.decode;
-import static org.jboss.aerogear.io.netty.handler.codec.sockjs.util.HttpUtil.decodeFullResponse;
 import static org.jboss.aerogear.io.netty.handler.codec.sockjs.util.HttpUtil.decodeFullHttpResponse;
 import static org.jboss.aerogear.io.netty.handler.codec.sockjs.util.HttpUtil.webSocketUpgradeRequest;
 import static org.hamcrest.CoreMatchers.nullValue;

--- a/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/NotificationHandler.java
+++ b/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/NotificationHandler.java
@@ -71,7 +71,7 @@ public class NotificationHandler extends SimpleChannelInboundHandler<Object> {
         if (msg instanceof FullHttpRequest) {
             final FullHttpRequest request = (FullHttpRequest) msg;
             final String requestUri = request.getUri();
-            logger.info(requestUri);
+            logger.debug(requestUri);
             if (requestUri.startsWith(simplePushServer.config().endpointPrefix())) {
                 handleHttpRequest(ctx, request);
             } else {

--- a/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/SimplePushServiceFactory.java
+++ b/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/SimplePushServiceFactory.java
@@ -19,11 +19,7 @@ package org.jboss.aerogear.simplepush.server.netty;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.AbstractSockJsServiceFactory;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsConfig;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsService;
-
-import org.jboss.aerogear.simplepush.server.DefaultSimplePushServer;
 import org.jboss.aerogear.simplepush.server.SimplePushServer;
-import org.jboss.aerogear.simplepush.server.SimplePushServerConfig;
-import org.jboss.aerogear.simplepush.server.datastore.DataStore;
 
 /**
  * Factory class that creates instances of {@link SimplePushSockJSService}.

--- a/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/SimplePushSockJSService.java
+++ b/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/SimplePushSockJSService.java
@@ -135,7 +135,7 @@ public class SimplePushSockJSService implements SockJsService {
                 logger.info("Cancelled Re-Acknowledger job");
             }
         } else if (ackJobFuture == null) {
-            ackJobFuture = session.getContext().executor().scheduleAtFixedRate(new Runnable() {
+            ackJobFuture = session.getConnectionContext().executor().scheduleAtFixedRate(new Runnable() {
                 @Override
                 public void run() {
                     final Set<Ack> unacked = simplePushServer.getUnacknowledged(uaid);

--- a/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/UserAgentReaper.java
+++ b/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/UserAgentReaper.java
@@ -61,14 +61,14 @@ public class UserAgentReaper implements Runnable {
                 // remove from database
                 simplePushServer.removeAllChannels(userAgent.uaid());
 
-                // close the user agent context
+                // close the user agent connectContext
                 userAgent.context().close();
             }
         }
     }
 
     private boolean isChannelInactive(final UserAgent<SockJsSessionContext> userAgent) {
-        final Channel ch = userAgent.context().getContext().channel();
+        final Channel ch = userAgent.context().getConnectionContext().channel();
         return !ch.isActive() && !ch.isRegistered();
     }
 }

--- a/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/WebSocketSslServerSslContext.java
+++ b/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/WebSocketSslServerSslContext.java
@@ -43,7 +43,7 @@ public final class WebSocketSslServerSslContext {
 
     /**
      * Creates a new {@link SSLContext}. This is an expensive operation and should only be done
-     * once and then the SSL context can be reused.
+     * once and then the SSL connectContext can be reused.
      *
      * @return {@link SSLContext} the SSLContext.
      */

--- a/server-netty/src/test/java/org/jboss/aerogear/simplepush/server/netty/NotificationHandlerTest.java
+++ b/server-netty/src/test/java/org/jboss/aerogear/simplepush/server/netty/NotificationHandlerTest.java
@@ -194,7 +194,12 @@ public class NotificationHandlerTest {
             }
 
             @Override
-            public ChannelHandlerContext getContext() {
+            public ChannelHandlerContext getConnectionContext() {
+                return null;
+            }
+
+            @Override
+            public ChannelHandlerContext getCurrentContext() {
                 return null;
             }
         };

--- a/server-netty/src/test/java/org/jboss/aerogear/simplepush/server/netty/UserAgentReaperTest.java
+++ b/server-netty/src/test/java/org/jboss/aerogear/simplepush/server/netty/UserAgentReaperTest.java
@@ -83,7 +83,7 @@ public class UserAgentReaperTest {
         final ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
         when(ctx.channel()).thenReturn(channel);
         final SockJsSessionContext sessionContext = mock(SockJsSessionContext.class);
-        when(sessionContext.getContext()).thenReturn(ctx);
+        when(sessionContext.getConnectionContext()).thenReturn(ctx);
         return sessionContext;
     }
 

--- a/server-netty/src/test/resources/sockjs-client.html
+++ b/server-netty/src/test/resources/sockjs-client.html
@@ -65,7 +65,7 @@
             div.scrollTop(div.scrollTop()+10000);
         };
 
-		sockjs.onopen    = function()  {
+		sockjs.onopen  = function()  {
 			print('[*] open', sockjs.protocol);
 		};
 
@@ -73,7 +73,7 @@
 			print('[.] message', e.data);
 		};
 
-		sockjs.onclose   = function()  {
+		sockjs.onclose  = function()  {
 			print('[*] close');
 		};
 

--- a/wildfly-module/src/main/resources/wildfly-config.cli
+++ b/wildfly-module/src/main/resources/wildfly-config.cli
@@ -7,7 +7,7 @@ batch
 
 ## Add SimplePush Netty Server
 /socket-binding-group=standard-sockets/socket-binding=simplepush:add(port=7777)
-/:composite(steps=[{"operation" => "add", "address" => [("subsystem" => "simplepush")]}, {"operation" => "add", "address" => [("subsystem" => "simplepush"), ("server" => "simplepush")], "socket-binding" => "simplepush", "datasource-jndi-name" => "java:jboss/datasources/SimplePushDS", "password" => "changeMe!", "notification-tls" => false, "sockjs-tls" => false}]
+/:composite(steps=[{"operation" => "add", "address" => [("subsystem" => "simplepush")]}, {"operation" => "add", "address" => [("subsystem" => "simplepush"), ("server" => "simplepush")], "socket-binding" => "simplepush", "datasource-jndi-name" => "java:jboss/datasources/SimplePushDS", "password" => "changeMe!", "notification-tls" => false, "sockjs-tls" => false, "sockjs-session-timeout" => 604800000L}]
 /:composite(steps=[{"operation" => "add", "address" => [("subsystem" => "simplepush"), ("server" => "simplepush"), ("datastore" => "in-memory")]}]
 
 run-batch


### PR DESCRIPTION
This PR is dependent upon https://github.com/aerogear/aerogear-simplepush-server/pull/66 which should be processed before this PR.

When testing locally you need to update standalone.xml by either running:

```
wildfly-8.0.0.Final/bin/jboss-cli.sh --file=wildfly-module/src/main/resources/wildfly-config.cli
```

Or manually updating standalone.xml:

```
<server socket-binding="simplepush" password="changeMe!" sockjs-session-timeout="604800000" sockjs-tls="false">
    <datastore>
        <in-memory/>
    </datastore>
</server>
```

A very basic client is available:
https://github.com/danbev/aerogear-simplepush-server/blob/AGSMPLPUSH-42-polling-transports-fix/server-netty/src/test/resources/sockjs-client.html
This has to be run in a web server and allows you to change the SockJS transport protocols.
