### PR TITLE
Revisit SockJS session handling

### DIFF
--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/SockJsSessionContext.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/SockJsSessionContext.java
@@ -38,10 +38,6 @@ public interface SockJsSessionContext {
     /**
      * Get the underlying ChannelHandlerContext.
      */
-    ChannelHandlerContext getConnectionContext();
+    ChannelHandlerContext getContext();
 
-    /**
-     * Get the underlying ChannelHandlerContext.
-     */
-    ChannelHandlerContext getCurrentContext();
 }

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/AbstractTimersSessionState.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/AbstractTimersSessionState.java
@@ -15,15 +15,16 @@
  */
 package org.jboss.aerogear.io.netty.handler.codec.sockjs.handler;
 
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
-
 import io.netty.channel.ChannelHandlerContext;
+import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsSessionContext;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.protocol.HeartbeatFrame;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.util.ArgumentUtil;
 import io.netty.util.concurrent.ScheduledFuture;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Base class for SessionState implementations that require timers.
@@ -36,16 +37,41 @@ abstract class AbstractTimersSessionState implements SessionState {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractTimersSessionState.class);
 
     private final ConcurrentMap<String, SockJsSession> sessions;
+    private final SockJsSession session;
     private ScheduledFuture<?> heartbeatFuture;
     private ScheduledFuture<?> sessionTimer;
 
-    protected AbstractTimersSessionState(final ConcurrentMap<String, SockJsSession> sessions) {
+    protected AbstractTimersSessionState(final ConcurrentMap<String, SockJsSession> sessions,
+                                         final SockJsSession session) {
         ArgumentUtil.checkNotNull(sessions, "sessions");
         this.sessions = sessions;
+        this.session = session;
+    }
+
+    protected SockJsSession getSockJsSession() {
+        return session;
     }
 
     @Override
-    public void onConnect(final SockJsSession session, final ChannelHandlerContext ctx) {
+    public State getState() {
+        return session.getState();
+    }
+
+    @Override
+    public void setState(final State state) {
+        session.setState(state);
+    }
+
+    @Override
+    public void onOpen(ChannelHandlerContext ctx) {
+        session.setInuse();
+        session.setOpenContext(ctx);
+    }
+
+    @Override
+    public void onConnect(final ChannelHandlerContext ctx, final SockJsSessionContext sockJsSessionContext) {
+        session.setConnectionContext(ctx);
+        session.onOpen(sockJsSessionContext);
         startSessionTimer(ctx, session);
         startHeartbeatTimer(ctx, session);
     }
@@ -56,7 +82,7 @@ abstract class AbstractTimersSessionState implements SessionState {
                 @Override
                 public void run() {
                     final long now = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
-                    if (isInUse(session)) {
+                    if (isInUse()) {
                         return;
                     }
                     if (session.timestamp() + session.config().sessionTimeout() < now) {
@@ -90,4 +116,29 @@ abstract class AbstractTimersSessionState implements SessionState {
         TimeUnit.MILLISECONDS);
     }
 
+    @Override
+    public void onClose() {
+        session.onClose();
+        session.resetInuse();
+    }
+
+    @Override
+    public void onMessage(String message) throws Exception {
+        session.onMessage(message);
+    }
+
+    @Override
+    public void setInuse() {
+        session.setInuse();
+    }
+
+    @Override
+    public void resetInuse() {
+        session.resetInuse();
+    }
+
+    @Override
+    public void storeMessage(String message) {
+        session.addMessage(message);
+    }
 }

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/PollingSessionState.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/PollingSessionState.java
@@ -25,7 +25,6 @@ import org.jboss.aerogear.io.netty.handler.codec.sockjs.protocol.MessageFrame;
 
 import java.util.concurrent.ConcurrentMap;
 
-
 /**
  * A polling state does not have a persistent connection to the client, instead a client
  * will connect, poll, to request data.
@@ -45,64 +44,59 @@ class PollingSessionState extends AbstractTimersSessionState {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(PollingSessionState.class);
     private final ConcurrentMap<String, SockJsSession> sessions;
 
-    PollingSessionState(final ConcurrentMap<String, SockJsSession> sessions) {
-        super(sessions);
+    PollingSessionState(final ConcurrentMap<String, SockJsSession> sessions, final SockJsSession session) {
+        super(sessions, session);
         this.sessions = sessions;
     }
 
     @Override
-    public void onOpen(final SockJsSession session, final ChannelHandlerContext ctx) {
-        flushMessages(ctx, session);
+    public void onOpen(final ChannelHandlerContext ctx) {
+        super.onOpen(ctx);
+        flushMessages(ctx);
     }
 
     @Override
-    public ChannelHandlerContext getSendingContext(SockJsSession session) {
-        final ChannelHandlerContext openContext = session.openContext();
-        return openContext == null ? session.connectionContext() : openContext;
+    public ChannelHandlerContext getSendingContext() {
+        final ChannelHandlerContext openContext = getSockJsSession().openContext();
+        return openContext == null ? getSockJsSession().connectionContext() : openContext;
     }
 
-    private void flushMessages(final ChannelHandlerContext ctx, final SockJsSession session) {
-        final String[] allMessages = session.getAllMessages();
+    private void flushMessages(final ChannelHandlerContext ctx) {
+        final String[] allMessages = getSockJsSession().getAllMessages();
         if (allMessages.length == 0) {
             return;
         }
         final MessageFrame messageFrame = new MessageFrame(allMessages);
-        ChannelFuture channelFuture = ctx.channel().writeAndFlush(messageFrame);
-        channelFuture.addListener(new ChannelFutureListener() {
+        ctx.channel().writeAndFlush(messageFrame).addListener(new ChannelFutureListener() {
             @Override
             public void operationComplete(final ChannelFuture future) throws Exception {
                 if (!future.isSuccess()) {
-                    session.addMessages(allMessages);
+                    getSockJsSession().addMessages(allMessages);
                 }
             }
-        });
-        channelFuture.addListener(ChannelFutureListener.CLOSE);
+        }).addListener(ChannelFutureListener.CLOSE);
     }
 
     @Override
-    public boolean isInUse(final SockJsSession session) {
-        return session.connectionContext().channel().isActive() || session.inuse();
+    public boolean isInUse() {
+        return getSockJsSession().connectionContext().channel().isActive() || getSockJsSession().inuse();
     }
 
     @Override
-    public void onSockJSServerInitiatedClose(final SockJsSession session) {
-        final ChannelHandlerContext context = session.connectionContext();
+    public void onSockJSServerInitiatedClose() {
+        final ChannelHandlerContext context = getSockJsSession().connectionContext();
         if (context != null) { //could be null if the request is aborted, for example due to missing callback.
             if (logger.isDebugEnabled()) {
-                logger.debug("Will close session connectionContext {}", session.connectionContext());
+                logger.debug("Will close session connectionContext {}", getSockJsSession().connectionContext());
             }
             context.close();
         }
-        sessions.remove(session.sessionId());
+        sessions.remove(getSockJsSession().sessionId());
     }
 
     @Override
     public String toString() {
         return StringUtil.simpleClassName(this);
-    }
-
-    @Override
-    public void onClose() {
     }
 
 }

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SessionHandler.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SessionHandler.java
@@ -15,45 +15,52 @@
  */
 package org.jboss.aerogear.io.netty.handler.codec.sockjs.handler;
 
-import io.netty.channel.*;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsSessionContext;
-import org.jboss.aerogear.io.netty.handler.codec.sockjs.handler.SockJsSession.States;
+import org.jboss.aerogear.io.netty.handler.codec.sockjs.handler.SessionState.State;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.protocol.CloseFrame;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.protocol.MessageFrame;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.protocol.OpenFrame;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.util.ArgumentUtil;
-import io.netty.util.ReferenceCountUtil;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
+
 
 /**
- * A Handler that manages SockJS sessions.
+ * A ChannelHandler that manages SockJS sessions.
  *
- * For every connection received a new SessionHandler will be created
- * and added to the pipeline
- * Depending on the type of connection (polling, streaming, send, or WebSocket)
+ * For every connection received a new SessionHandler will be created and added to
+ * the pipeline.
+ *
+ * Depending on the type of connection (polling, streaming, send, or websocket)
  * the type of {@link SessionState} that this session handles will differ.
  *
  */
-public class SessionHandler extends ChannelHandlerAdapter implements SockJsSessionContext {
+public class SessionHandler extends ChannelHandlerAdapter {
+
+    public enum Event { CLOSE_SESSION, HANDLE_SESSION }
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(SessionHandler.class);
-    public enum Events { CLOSE_SESSION, HANDLE_SESSION }
 
     private final SessionState sessionState;
-    private final SockJsSession session;
 
-    public SessionHandler(final SessionState sessionState, final SockJsSession session) {
+    public SessionHandler(final SessionState sessionState) {
         ArgumentUtil.checkNotNull(sessionState, "sessionState");
         this.sessionState = sessionState;
-        this.session = session;
     }
 
     @Override
     public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
-        session.setCurrentContext(ctx);
         if (msg instanceof HttpRequest) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Handle session : {}", sessionState);
+            }
+            ReferenceCountUtil.release(msg);
             handleSession(ctx);
         } else if (msg instanceof String) {
             handleMessage((String) msg);
@@ -62,58 +69,57 @@ public class SessionHandler extends ChannelHandlerAdapter implements SockJsSessi
         }
     }
 
-    private void handleSession(final ChannelHandlerContext ctx) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("handleSession {}", sessionState);
-        }
-        switch (session.getState()) {
+    private void handleSession(final ChannelHandlerContext ctx) throws Exception {
+        switch (sessionState.getState()) {
         case CONNECTING:
-            logger.debug("State.CONNECTING sending open frame");
-            ctx.channel().writeAndFlush(new OpenFrame());
-            session.setConnectionContext(ctx);
-            session.onOpen(this);
-            sessionState.onConnect(session, ctx);
+            sessionConnecting(ctx);
             break;
         case OPEN:
-            if (sessionState.isInUse(session)) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Another connection still in open for [{}]", session.sessionId());
-                }
-                ctx.writeAndFlush(new CloseFrame(2010, "Another connection still open"));
-                session.setState(States.INTERRUPTED);
-            } else {
-                session.setInuse();
-                session.setOpenContext(ctx);
-                sessionState.onOpen(session, ctx);
-            }
+            sessionOpen(ctx);
             break;
         case INTERRUPTED:
-            ctx.writeAndFlush(new CloseFrame(1002, "Connection interrupted"));
+            sessionInterrupted(ctx);
             break;
         case CLOSED:
-            ctx.writeAndFlush(new CloseFrame(3000, "Go away!"));
-            session.resetInuse();
+            sessionClosed(ctx);
             break;
         }
+    }
+
+    private void sessionConnecting(final ChannelHandlerContext ctx) {
+        logger.debug("State.CONNECTING sending open frame");
+        writeOpenFrame(ctx);
+        sessionState.onConnect(ctx, new DefaultSockJsSessionContext());
+    }
+
+    private void sessionOpen(ChannelHandlerContext ctx) {
+        if (sessionState.isInUse()) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Another connection still in open for {}", sessionState);
+            }
+            writeCloseFrame(ctx, 2010, "Another connection still open");
+            sessionState.setState(State.INTERRUPTED);
+        } else {
+            sessionState.onOpen(ctx);
+        }
+    }
+
+    private void sessionInterrupted(ChannelHandlerContext ctx) {
+        writeCloseFrame(ctx, 1002, "Connection interrupted");
+    }
+
+    private void sessionClosed(ChannelHandlerContext ctx) {
+        writeCloseFrame(ctx, 3000, "Go away!");
+        sessionState.onClose();
     }
 
     private void handleMessage(final String message) throws Exception {
-        session.onMessage(message);
-    }
-
-    @Override
-    public void send(String message) {
-        final Channel channel = sessionState.getSendingContext(session).channel();
-        if (isWritable(channel)) {
-            channel.writeAndFlush(new MessageFrame(message));
-        } else {
-            session.addMessage(message);
-        }
+        sessionState.onMessage(message);
     }
 
     @Override
     public void channelInactive(final ChannelHandlerContext ctx) throws Exception {
-        session.resetInuse();
+        sessionState.resetInuse();
         ctx.fireChannelInactive();
     }
 
@@ -122,37 +128,52 @@ public class SessionHandler extends ChannelHandlerAdapter implements SockJsSessi
     }
 
     @Override
-    public void close() {
-        session.onClose();
-        sessionState.onClose();
-        final Channel channel = sessionState.getSendingContext(session).channel();
-        if (isWritable(channel)) {
-            final CloseFrame closeFrame = new CloseFrame(3000, "Go away!");
-            if (logger.isDebugEnabled()) {
-                logger.debug("Writing {}", closeFrame);
-            }
-            channel.writeAndFlush(closeFrame).addListener(ChannelFutureListener.CLOSE);
-        }
-    }
-
-    @Override
     public void userEventTriggered(final ChannelHandlerContext ctx, final Object event) throws Exception {
-        if (event == Events.CLOSE_SESSION) {
-            session.onClose();
-            sessionState.onSockJSServerInitiatedClose(session);
-        } else if (event == Events.HANDLE_SESSION) {
+        if (event == Event.CLOSE_SESSION) {
+            sessionState.onClose();
+            sessionState.onSockJSServerInitiatedClose();
+        } else if (event == Event.HANDLE_SESSION) {
             handleSession(ctx);
         }
     }
 
-    @Override
-    public ChannelHandlerContext getConnectionContext() {
-        return session.connectionContext();
+    private static void writeCloseFrame(final ChannelHandlerContext ctx, final int code, final String message) {
+        ctx.channel().writeAndFlush(new CloseFrame(code, message));
     }
 
-    @Override
-    public ChannelHandlerContext getCurrentContext() {
-        return session.currentContext();
+    private static void writeOpenFrame(final ChannelHandlerContext ctx) {
+        ctx.channel().writeAndFlush(new OpenFrame());
+    }
+
+    public class DefaultSockJsSessionContext implements SockJsSessionContext {
+
+        @Override
+        public void send(String message) {
+            final Channel channel = sessionState.getSendingContext().channel();
+            if (isWritable(channel)) {
+                channel.writeAndFlush(new MessageFrame(message));
+            } else {
+                sessionState.storeMessage(message);
+            }
+        }
+
+        @Override
+        public void close() {
+            sessionState.onClose();
+            final Channel channel = sessionState.getSendingContext().channel();
+            if (isWritable(channel)) {
+                final CloseFrame closeFrame = new CloseFrame(3000, "Go away!");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Writing {}", closeFrame);
+                }
+                channel.writeAndFlush(closeFrame).addListener(ChannelFutureListener.CLOSE);
+            }
+        }
+
+        @Override
+        public ChannelHandlerContext getContext() {
+            return sessionState.getSendingContext();
+        }
     }
 
 }

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SessionState.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SessionState.java
@@ -16,6 +16,7 @@
 package org.jboss.aerogear.io.netty.handler.codec.sockjs.handler;
 
 import io.netty.channel.ChannelHandlerContext;
+import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsSessionContext;
 
 /**
  * A SessionState represents differences in the types of sessions possible with SockJS.
@@ -27,33 +28,65 @@ import io.netty.channel.ChannelHandlerContext;
  */
 interface SessionState {
 
+    enum State {
+        CONNECTING,
+        OPEN,
+        CLOSED,
+        INTERRUPTED }
+
+    /**
+     * Returns the current session state.
+     *
+     * @return {@code State} the {@link State} of the session
+     */
+    State getState();
+
+    /**
+     * Sets this session state.
+     *
+     * @param state the new state for this session
+     */
+    void setState(State state);
+
     /**
      * Called when a new session is connecting.
      *
-     * @param session the {@link SockJsSession}.
      * @param ctx the {@link ChannelHandlerContext} for the current connection/channel
+     * @param sockJsSessionContext the {@link SockJsSessionContext} for the current connection/channel
      */
-    void onConnect(SockJsSession session, ChannelHandlerContext ctx);
+    void onConnect(ChannelHandlerContext ctx, SockJsSessionContext sockJsSessionContext);
 
     /**
      * Called when a request for a connected session is received.
      *
-     * @param session the {@link SockJsSession}.
      * @param ctx the {@link ChannelHandlerContext} for the current connection/channel. Note
      *            that this ChannelHandlerContext is different from the one that opened the
      *            the sesssion and was passed to the onConnect method.
      */
-    void onOpen(SockJsSession session, ChannelHandlerContext ctx);
+    void onOpen(ChannelHandlerContext ctx);
+
+    /**
+     * Called when a message is to be sent to the SockJS service.
+     *
+     * @param message the message.
+     */
+    void onMessage(String message) throws Exception;
+
+    /**
+     * Stores the message in the session for later delivery to when a client is
+     * connected.
+     *
+     */
+    void storeMessage(String message);
 
     /**
      * Returns the ChannelHandlerContext that should be used to communicate with the client.
      * This may be different for different transports. For some transports this will be the
      * context that opened the connection and others it will be the current context.
      *
-     * @param session the {@link SockJsSession}.
      * @return {@code ChannelHandlerContext} the context to be used for sending.
      */
-    ChannelHandlerContext getSendingContext(SockJsSession session);
+    ChannelHandlerContext getSendingContext();
 
     /**
      * Called after the {@link SockJsSession#onClose()} method has been called enabling
@@ -64,13 +97,23 @@ interface SessionState {
     /**
      * Called when the SockJS server has initiated a close of the session.
      */
-    void onSockJSServerInitiatedClose(SockJsSession session);
+    void onSockJSServerInitiatedClose();
 
     /**
-     * Indicates if this session is in use.
+     * Indicates if the underlying session is in use.
      *
      * @return {@code true} if the session is in use.
      */
-    boolean isInUse(SockJsSession session);
+    boolean isInUse();
+
+    /**
+     * Sets the underlying session as inuse.
+     */
+    void setInuse();
+
+    /**
+     * Resets the underlyig session as no longer inuse.
+     */
+    void resetInuse();
 
 }

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SockJsHandler.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SockJsHandler.java
@@ -128,37 +128,37 @@ public class SockJsHandler extends SimpleChannelInboundHandler<FullHttpRequest> 
         switch (pathParams.transport()) {
         case XHR:
             addTransportHandler(new XhrPollingTransport(factory.config(), request), ctx);
-            addSessionHandler(new PollingSessionState(sessions), getSession(factory, pathParams.sessionId()), ctx);
+            addSessionHandler(new PollingSessionState(sessions, getSession(factory, pathParams.sessionId())), ctx);
             break;
         case JSONP:
             addTransportHandler(new JsonpPollingTransport(factory.config(), request), ctx);
-            addSessionHandler(new PollingSessionState(sessions), getSession(factory, pathParams.sessionId()), ctx);
+            addSessionHandler(new PollingSessionState(sessions, getSession(factory, pathParams.sessionId())), ctx);
             break;
         case XHR_SEND:
             checkSessionExists(pathParams.sessionId(), request);
             addTransportHandler(new XhrSendTransport(factory.config()), ctx);
-            addSessionHandler(new SendingSessionState(sessions), sessions.get(pathParams.sessionId()), ctx);
+            addSessionHandler(new SendingSessionState(sessions, sessions.get(pathParams.sessionId())), ctx);
             break;
         case XHR_STREAMING:
             addTransportHandler(new XhrStreamingTransport(factory.config(), request), ctx);
-            addSessionHandler(new StreamingSessionState(sessions), getSession(factory, pathParams.sessionId()), ctx);
+            addSessionHandler(new StreamingSessionState(sessions, getSession(factory, pathParams.sessionId())), ctx);
             break;
         case EVENTSOURCE:
             addTransportHandler(new EventSourceTransport(factory.config(), request), ctx);
-            addSessionHandler(new StreamingSessionState(sessions), getSession(factory, pathParams.sessionId()), ctx);
+            addSessionHandler(new StreamingSessionState(sessions, getSession(factory, pathParams.sessionId())), ctx);
             break;
         case HTMLFILE:
             addTransportHandler(new HtmlFileTransport(factory.config(), request), ctx);
-            addSessionHandler(new StreamingSessionState(sessions), getSession(factory, pathParams.sessionId()), ctx);
+            addSessionHandler(new StreamingSessionState(sessions, getSession(factory, pathParams.sessionId())), ctx);
             break;
         case JSONP_SEND:
             checkSessionExists(pathParams.sessionId(), request);
             addTransportHandler(new JsonpSendTransport(factory.config()), ctx);
-            addSessionHandler(new SendingSessionState(sessions), sessions.get(pathParams.sessionId()), ctx);
+            addSessionHandler(new SendingSessionState(sessions, sessions.get(pathParams.sessionId())), ctx);
             break;
         case WEBSOCKET:
             addTransportHandler(new WebSocketTransport(factory.config()), ctx);
-            addSessionHandler(new WebSocketSessionState(), new SockJsSession(randomUUID().toString(), factory.create()),
+            addSessionHandler(new WebSocketSessionState(new SockJsSession(randomUUID().toString(), factory.create())),
                     ctx);
             break;
         }
@@ -169,9 +169,8 @@ public class SockJsHandler extends SimpleChannelInboundHandler<FullHttpRequest> 
         ctx.pipeline().addLast(transportHandler);
     }
 
-    private static void addSessionHandler(final SessionState sessionState, final SockJsSession session,
-                                          final ChannelHandlerContext ctx) {
-        ctx.pipeline().addLast(new SessionHandler(sessionState, session));
+    private static void addSessionHandler(final SessionState sessionState, final ChannelHandlerContext ctx) {
+        ctx.pipeline().addLast(new SessionHandler(sessionState));
     }
 
     private static void checkSessionExists(final String sessionId, final HttpRequest request)
@@ -239,12 +238,12 @@ public class SockJsHandler extends SimpleChannelInboundHandler<FullHttpRequest> 
         }
     }
 
-    private static class SessionNotFoundException extends Exception {
+    private static final class SessionNotFoundException extends Exception {
         private static final long serialVersionUID = 1101611486620901143L;
         private final String sessionId;
         private final HttpRequest request;
 
-        public SessionNotFoundException(final String sessionId, final HttpRequest request) {
+        private SessionNotFoundException(final String sessionId, final HttpRequest request) {
             this.sessionId = sessionId;
             this.request = request;
         }

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SockJsSession.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SockJsSession.java
@@ -19,29 +19,27 @@ import io.netty.channel.ChannelHandlerContext;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsConfig;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsSessionContext;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsService;
+import org.jboss.aerogear.io.netty.handler.codec.sockjs.handler.SessionState.State;
 import io.netty.util.internal.StringUtil;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 class SockJsSession {
 
-
-    enum States { CONNECTING, OPEN, CLOSED, INTERRUPTED }
-
-    private States state = States.CONNECTING;
+    private State state = State.CONNECTING;
     private final String sessionId;
     private final SockJsService service;
-    private final LinkedList<String> messages = new LinkedList<String>();
+    private final List<String> messages = new ArrayList<String>();
     private final AtomicLong timestamp = new AtomicLong();
     private final AtomicBoolean inuse = new AtomicBoolean();
     private ChannelHandlerContext connectionContext;
-    private ChannelHandlerContext currentContext;
     private ChannelHandlerContext openContext;
 
-    public SockJsSession(final String sessionId, final SockJsService service) {
+    protected SockJsSession(final String sessionId, final SockJsService service) {
         this.sessionId = sessionId;
         this.service = service;
     }
@@ -82,29 +80,11 @@ class SockJsSession {
         openContext = ctx;
     }
 
-    /**
-     * Returns the ChannelHandlerContext for the current connection.
-     *
-     * @return {@code ChannelHandlerContext} the ChannelHandlerContext for the current connection
-     */
-    public synchronized ChannelHandlerContext currentContext() {
-        return currentContext;
-    }
-
-    /**
-     * Sets the ChannelHandlerContext for the current connection.
-     *
-     * @param ctx the ChannelHandlerContext for the current connection.
-     */
-    public synchronized void setCurrentContext(final ChannelHandlerContext ctx) {
-        currentContext = ctx;
-    }
-
-    public synchronized void setState(States state) {
+    public synchronized void setState(State state) {
         this.state = state;
     }
 
-    public synchronized States getState() {
+    public synchronized State getState() {
         return state;
     }
 
@@ -134,13 +114,13 @@ class SockJsSession {
     }
 
     public synchronized void onOpen(final SockJsSessionContext session) {
-        setState(States.OPEN);
+        setState(State.OPEN);
         service.onOpen(session);
         updateTimestamp();
     }
 
     public synchronized void onClose() {
-        setState(States.CLOSED);
+        setState(State.CLOSED);
         service.onClose();
     }
 

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/WebSocketSessionState.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/WebSocketSessionState.java
@@ -18,6 +18,7 @@ package org.jboss.aerogear.io.netty.handler.codec.sockjs.handler;
 import java.util.concurrent.TimeUnit;
 
 import io.netty.channel.ChannelHandlerContext;
+import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsSessionContext;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.protocol.HeartbeatFrame;
 import io.netty.util.concurrent.ScheduledFuture;
 import io.netty.util.internal.StringUtil;
@@ -32,11 +33,28 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  */
 class WebSocketSessionState implements SessionState {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(WebSocketSessionState.class);
+    private final SockJsSession session;
 
     private ScheduledFuture<?> heartbeatFuture;
 
+    WebSocketSessionState(final SockJsSession session) {
+        this.session = session;
+    }
+
     @Override
-    public void onConnect(final SockJsSession session, final ChannelHandlerContext ctx) {
+    public State getState() {
+        return session.getState();
+    }
+
+    @Override
+    public void setState(final State state) {
+        session.setState(state);
+    }
+
+    @Override
+    public void onConnect(final ChannelHandlerContext ctx, final SockJsSessionContext sockJsSessionContext) {
+        session.setConnectionContext(ctx);
+        session.onOpen(sockJsSessionContext);
         startHeartbeatTimer(ctx, session);
     }
 
@@ -61,21 +79,42 @@ class WebSocketSessionState implements SessionState {
     }
 
     @Override
-    public void onOpen(final SockJsSession session, final ChannelHandlerContext ctx) {
+    public void onOpen(final ChannelHandlerContext ctx) {
+        session.setInuse();
     }
 
     @Override
-    public ChannelHandlerContext getSendingContext(SockJsSession session) {
+    public void onMessage(String message) throws Exception {
+        session.onMessage(message);
+    }
+
+    @Override
+    public void storeMessage(String message) {
+        session.addMessage(message);
+    }
+
+    @Override
+    public ChannelHandlerContext getSendingContext() {
         return session.connectionContext();
     }
 
     @Override
-    public boolean isInUse(final SockJsSession session) {
+    public boolean isInUse() {
         return session.connectionContext().channel().isActive();
     }
 
     @Override
-    public void onSockJSServerInitiatedClose(final SockJsSession session) {
+    public void setInuse() {
+        // NoOp
+    }
+
+    @Override
+    public void resetInuse() {
+        // NoOp
+    }
+
+    @Override
+    public void onSockJSServerInitiatedClose() {
         shutdownHearbeat();
     }
 
@@ -86,6 +125,8 @@ class WebSocketSessionState implements SessionState {
 
     @Override
     public void onClose() {
+        session.onClose();
+        session.resetInuse();
         shutdownHearbeat();
     }
 

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/transport/EventSourceTransport.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/transport/EventSourceTransport.java
@@ -23,7 +23,10 @@ import static io.netty.handler.codec.http.HttpConstants.LF;
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
 import static io.netty.buffer.Unpooled.copiedBuffer;
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.*;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -43,7 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * EventSource transport is an streaming transport in that is maintains a persistent
  * connection from the server to the client over which the server can send messages.
- * This is often refered to a Server Side Events (SSE) and the client side.
+ * This is often refered to a Server Side Event (SSE) and the client side.
  *
  * The response for opening such a unidirection channel is done with a simple
  * plain response with a 'Content-Type' of 'text/event-stream'. Subsequent

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/transport/JsonpPollingTransport.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/transport/JsonpPollingTransport.java
@@ -15,6 +15,12 @@
  */
 package org.jboss.aerogear.io.netty.handler.codec.sockjs.transport;
 
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.util.CharsetUtil.UTF_8;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerAdapter;
@@ -28,16 +34,12 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.QueryStringDecoder;
-import io.netty.util.ReferenceCountUtil;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsConfig;
-import org.jboss.aerogear.io.netty.handler.codec.sockjs.handler.SessionHandler.Events;
+import org.jboss.aerogear.io.netty.handler.codec.sockjs.handler.SessionHandler.Event;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.protocol.Frame;
+import io.netty.util.ReferenceCountUtil;
 
 import java.util.List;
-
-import static io.netty.handler.codec.http.HttpHeaders.Names.*;
-import static io.netty.handler.codec.http.HttpResponseStatus.*;
-import static io.netty.util.CharsetUtil.*;
 
 /**
  * JSON Padding (JSONP) Polling is a transport where there is no open connection between
@@ -59,7 +61,6 @@ public class JsonpPollingTransport extends ChannelHandlerAdapter {
 
     public JsonpPollingTransport(final SockJsConfig config, final FullHttpRequest request) {
         this.request = request;
-        this.request.retain();
         this.config = config;
     }
 
@@ -70,7 +71,7 @@ public class JsonpPollingTransport extends ChannelHandlerAdapter {
             final List<String> c = qsd.parameters().get("c");
             if (c == null) {
                 respond(ctx, request.getProtocolVersion(), INTERNAL_SERVER_ERROR, "\"callback\" parameter required");
-                ctx.fireUserEventTriggered(Events.CLOSE_SESSION);
+                ctx.fireUserEventTriggered(Event.CLOSE_SESSION);
                 return;
             } else {
                 callback = c.get(0);

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/transport/RawWebSocketTransport.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/transport/RawWebSocketTransport.java
@@ -129,11 +129,7 @@ public class RawWebSocketTransport extends SimpleChannelInboundHandler<Object> {
                                 ctx.close();
                             }
                             @Override
-                            public ChannelHandlerContext getConnectionContext() {
-                                return ctx;
-                            }
-                            @Override
-                            public ChannelHandlerContext getCurrentContext() {
+                            public ChannelHandlerContext getContext() {
                                 return ctx;
                             }
                         });

--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/transport/WebSocketHAProxyTransport.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/transport/WebSocketHAProxyTransport.java
@@ -31,12 +31,11 @@ import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
-import org.jboss.aerogear.io.netty.handler.codec.sockjs.handler.SessionHandler;
+import org.jboss.aerogear.io.netty.handler.codec.sockjs.handler.SessionHandler.Event;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.util.JsonUtil;
 import io.netty.util.AttributeKey;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-
 
 /**
  * WebSocketTransport is responsible for the WebSocket handshake and
@@ -59,7 +58,7 @@ public class WebSocketHAProxyTransport extends SimpleChannelInboundHandler<Objec
         } else if (msg instanceof WebSocketFrame) {
             handleWebSocketFrame(ctx, (WebSocketFrame) msg);
         }
-        ctx.fireUserEventTriggered(SessionHandler.Events.HANDLE_SESSION);
+        ctx.fireUserEventTriggered(Event.HANDLE_SESSION);
     }
 
     private void handleContent(final ChannelHandlerContext ctx, final ByteBuf nounce) {

--- a/netty-codec-sockjs/src/test/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SockJsSessionTest.java
+++ b/netty-codec-sockjs/src/test/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/SockJsSessionTest.java
@@ -21,8 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsSessionContext;
 import org.jboss.aerogear.io.netty.handler.codec.sockjs.SockJsService;
-import org.jboss.aerogear.io.netty.handler.codec.sockjs.handler.SockJsSession;
-import org.jboss.aerogear.io.netty.handler.codec.sockjs.handler.SockJsSession.States;
+import org.jboss.aerogear.io.netty.handler.codec.sockjs.handler.SessionState.State;
 
 import org.junit.Test;
 
@@ -32,8 +31,8 @@ public class SockJsSessionTest {
     public void setState() throws Exception {
         final SockJsService service = mock(SockJsService.class);
         final SockJsSession session = new SockJsSession("123", service);
-        session.setState(States.OPEN);
-        assertThat(session.getState(), is(States.OPEN));
+        session.setState(State.OPEN);
+        assertThat(session.getState(), is(State.OPEN));
     }
 
     @Test
@@ -43,7 +42,7 @@ public class SockJsSessionTest {
         final SockJsSessionContext session = mock(SockJsSessionContext.class);
         sockJSSession.onOpen(session);
         verify(service).onOpen(session);
-        assertThat(sockJSSession.getState(), is(States.OPEN));
+        assertThat(sockJSSession.getState(), is(State.OPEN));
     }
 
     @Test

--- a/netty-codec-sockjs/src/test/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/protocol/SockJsProtocolTest.java
+++ b/netty-codec-sockjs/src/test/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/protocol/SockJsProtocolTest.java
@@ -69,8 +69,8 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 
 import static io.netty.handler.codec.http.HttpHeaders.Names.*;
-import static io.netty.handler.codec.http.HttpHeaders.Names.UPGRADE;
-import static io.netty.handler.codec.http.HttpHeaders.Values.*;
+import static io.netty.handler.codec.http.HttpHeaders.Values.WEBSOCKET;
+import static io.netty.handler.codec.http.HttpHeaders.Values.KEEP_ALIVE;
 import static io.netty.handler.codec.http.HttpMethod.*;
 import static io.netty.handler.codec.http.HttpVersion.*;
 import static io.netty.handler.codec.http.websocketx.WebSocketVersion.*;
@@ -83,7 +83,9 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class SockJsProtocolTest {
 

--- a/netty-codec-sockjs/src/test/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/util/StubEmbeddedEventLoop.java
+++ b/netty-codec-sockjs/src/test/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/util/StubEmbeddedEventLoop.java
@@ -18,7 +18,12 @@ package org.jboss.aerogear.io.netty.handler.codec.sockjs.util;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.netty.channel.*;
+import io.netty.channel.AbstractEventLoop;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelHandlerInvoker;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ScheduledFuture;

--- a/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/SimplePushSockJSService.java
+++ b/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/SimplePushSockJSService.java
@@ -135,7 +135,7 @@ public class SimplePushSockJSService implements SockJsService {
                 logger.info("Cancelled Re-Acknowledger job");
             }
         } else if (ackJobFuture == null) {
-            ackJobFuture = session.getConnectionContext().executor().scheduleAtFixedRate(new Runnable() {
+            ackJobFuture = session.getContext().executor().scheduleAtFixedRate(new Runnable() {
                 @Override
                 public void run() {
                     final Set<Ack> unacked = simplePushServer.getUnacknowledged(uaid);

--- a/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/UserAgentReaper.java
+++ b/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/UserAgentReaper.java
@@ -68,7 +68,7 @@ public class UserAgentReaper implements Runnable {
     }
 
     private boolean isChannelInactive(final UserAgent<SockJsSessionContext> userAgent) {
-        final Channel ch = userAgent.context().getConnectionContext().channel();
+        final Channel ch = userAgent.context().getContext().channel();
         return !ch.isActive() && !ch.isRegistered();
     }
 }

--- a/server-netty/src/test/java/org/jboss/aerogear/simplepush/server/netty/NotificationHandlerTest.java
+++ b/server-netty/src/test/java/org/jboss/aerogear/simplepush/server/netty/NotificationHandlerTest.java
@@ -194,14 +194,10 @@ public class NotificationHandlerTest {
             }
 
             @Override
-            public ChannelHandlerContext getConnectionContext() {
+            public ChannelHandlerContext getContext() {
                 return null;
             }
 
-            @Override
-            public ChannelHandlerContext getCurrentContext() {
-                return null;
-            }
         };
     }
 

--- a/server-netty/src/test/java/org/jboss/aerogear/simplepush/server/netty/StubEmbeddedEventLoop.java
+++ b/server-netty/src/test/java/org/jboss/aerogear/simplepush/server/netty/StubEmbeddedEventLoop.java
@@ -18,14 +18,20 @@ package org.jboss.aerogear.simplepush.server.netty;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.netty.channel.AbstractEventLoop;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelHandlerInvoker;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
-import io.netty.util.concurrent.AbstractEventExecutor;
+import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ScheduledFuture;
 
+import java.net.SocketAddress;
 import java.util.concurrent.TimeUnit;
+
+import static io.netty.channel.ChannelHandlerInvokerUtil.*;
 
 /**
  * The sole purpose of this class it to work around that the EmbeddedEventLoop of
@@ -37,11 +43,12 @@ import java.util.concurrent.TimeUnit;
  * Note that schuduleAtFixedRate will actually not run the command given to it, but instead
  * just return a ScheduledFuture that is marked as successful.
  */
-public class StubEmbeddedEventLoop extends AbstractEventExecutor implements EventLoop {
+public class StubEmbeddedEventLoop extends AbstractEventLoop implements ChannelHandlerInvoker {
 
     private final EventLoop delegate;
 
     public StubEmbeddedEventLoop(final EventLoop delegate) {
+        super(delegate);
         this.delegate = delegate;
     }
 
@@ -112,11 +119,93 @@ public class StubEmbeddedEventLoop extends AbstractEventExecutor implements Even
 
     @Override
     public ChannelHandlerInvoker asInvoker() {
-        return delegate.asInvoker();
+        return this;
     }
 
     @Override
     public EventLoopGroup parent() {
         return delegate.parent();
+    }
+
+    @Override
+    public EventExecutor executor() {
+        return this;
+    }
+
+    @Override
+    public void invokeChannelRegistered(ChannelHandlerContext ctx) {
+        invokeChannelRegisteredNow(ctx);
+    }
+
+    @Override
+    public void invokeChannelActive(ChannelHandlerContext ctx) {
+        invokeChannelActiveNow(ctx);
+    }
+
+    @Override
+    public void invokeChannelInactive(ChannelHandlerContext ctx) {
+        invokeChannelInactiveNow(ctx);
+    }
+
+    @Override
+    public void invokeExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        invokeExceptionCaughtNow(ctx, cause);
+    }
+
+    @Override
+    public void invokeUserEventTriggered(ChannelHandlerContext ctx, Object event) {
+        invokeUserEventTriggeredNow(ctx, event);
+    }
+
+    @Override
+    public void invokeChannelRead(ChannelHandlerContext ctx, Object msg) {
+        invokeChannelReadNow(ctx, msg);
+    }
+
+    @Override
+    public void invokeChannelReadComplete(ChannelHandlerContext ctx) {
+        invokeChannelReadCompleteNow(ctx);
+    }
+
+    @Override
+    public void invokeChannelWritabilityChanged(ChannelHandlerContext ctx) {
+        invokeChannelWritabilityChangedNow(ctx);
+    }
+
+    @Override
+    public void invokeBind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
+        invokeBindNow(ctx, localAddress, promise);
+    }
+
+    @Override
+    public void invokeConnect(
+            ChannelHandlerContext ctx,
+            SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+        invokeConnectNow(ctx, remoteAddress, localAddress, promise);
+    }
+
+    @Override
+    public void invokeDisconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
+        invokeDisconnectNow(ctx, promise);
+    }
+
+    @Override
+    public void invokeClose(ChannelHandlerContext ctx, ChannelPromise promise) {
+        invokeCloseNow(ctx, promise);
+    }
+
+    @Override
+    public void invokeRead(ChannelHandlerContext ctx) {
+        invokeReadNow(ctx);
+    }
+
+    @Override
+    public void invokeWrite(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+        invokeWriteNow(ctx, msg, promise);
+    }
+
+    @Override
+    public void invokeFlush(ChannelHandlerContext ctx) {
+        invokeFlushNow(ctx);
     }
 }

--- a/server-netty/src/test/java/org/jboss/aerogear/simplepush/server/netty/UserAgentReaperTest.java
+++ b/server-netty/src/test/java/org/jboss/aerogear/simplepush/server/netty/UserAgentReaperTest.java
@@ -83,7 +83,7 @@ public class UserAgentReaperTest {
         final ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
         when(ctx.channel()).thenReturn(channel);
         final SockJsSessionContext sessionContext = mock(SockJsSessionContext.class);
-        when(sessionContext.getConnectionContext()).thenReturn(ctx);
+        when(sessionContext.getContext()).thenReturn(ctx);
         return sessionContext;
     }
 

--- a/server-netty/src/test/resources/sockjs-client.html
+++ b/server-netty/src/test/resources/sockjs-client.html
@@ -48,9 +48,9 @@
 
     <script>
         var sockjs_url = 'http://localhost:7777/simplepush';
-        //var sockjs = new SockJS(sockjs_url);
+        var sockjs = new SockJS(sockjs_url);
         //var sockjs = new SockJS(sockjs_url, null, {"debug": true, "protocols_whitelist": ["jsonp-polling"]});
-        var sockjs = new SockJS(sockjs_url, null, {"debug": true, "protocols_whitelist": ["xhr-polling"]});
+        //var sockjs = new SockJS(sockjs_url, null, {"debug": true, "protocols_whitelist": ["xhr-polling"]});
         //var sockjs = new SockJS(sockjs_url, null, {"debug": true, "protocols_whitelist": ["xhr-streaming"]});
 
         $('#first input').focus();


### PR DESCRIPTION
The session handling in SockJS was too complicated and fragile. This
PR is a simplification of the handling of sessions mainly focused on
sipmlifying the SessionHandler class.
- These changes are a port of the same code in Netty SockJS
- These changes have been verified and are inline with the
  sockjs-protocol-0.3.3 testsuite.

[https://issues.jboss.org/browse/AGSMPLPUSH-50]
