### PR TITLE
Removing the requirement of a version in the notification body.

### DIFF
--- a/common/src/main/java/org/jboss/aerogear/simplepush/util/VersionExtractor.java
+++ b/common/src/main/java/org/jboss/aerogear/simplepush/util/VersionExtractor.java
@@ -30,6 +30,9 @@ public final class VersionExtractor {
     }
 
     public static String extractVersion(final String payload) {
+        if (payload == null || "".equals(payload)) {
+            return String.valueOf(System.currentTimeMillis());
+        }
         final Matcher matcher = VERSION_PATTERN.matcher(payload);
         if (matcher.find()) {
             return matcher.group(1);

--- a/common/src/test/java/org/jboss/aerogear/simplepush/util/VersionExtractorTest.java
+++ b/common/src/test/java/org/jboss/aerogear/simplepush/util/VersionExtractorTest.java
@@ -17,6 +17,8 @@
 package org.jboss.aerogear.simplepush.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
@@ -31,6 +33,22 @@ public class VersionExtractorTest {
         assertThat(VersionExtractor.extractVersion(" version=10"), equalTo("10"));
         assertThat(VersionExtractor.extractVersion(" version= 11"), equalTo("11"));
         assertThat(VersionExtractor.extractVersion(" version = 12 "), equalTo("12"));
+    }
+
+    @Test
+    public void noVersion() {
+        assertThat(VersionExtractor.extractVersion(""), is(notNullValue()));
+        assertThat(VersionExtractor.extractVersion(null), is(notNullValue()));
+    }
+
+    @Test (expected = RuntimeException.class)
+    public void invalidVersionPropertyName() {
+        VersionExtractor.extractVersion("vorsion=12");
+    }
+
+    @Test (expected = RuntimeException.class)
+    public void invalidVersion() {
+        VersionExtractor.extractVersion("version=");
     }
 
 }

--- a/server-core/README.md
+++ b/server-core/README.md
@@ -93,6 +93,10 @@ A notification is triggered by sending a ```PUT``` request to the ```pushEndpoin
     ContentType: application/x-www-form-urlencoded
     
     version=N
+
+The body of the PUT request is optional, and if not present the server will generate the field automatically setting
+it to the current Coordinated Universal Time (UTC) as specified in the
+[SimplePush Protocol](https://wiki.mozilla.org/WebAPI/SimplePush/Protocol#Notification).
     
 #### Response (PUT) format
 


### PR DESCRIPTION
It will no longer be mandatory to have a version property in the PUT
request body. Instead, if the version property is left out the server
will generate a UTC date for the version which will be delivered to the
registered channel.

[https://issues.jboss.org/browse/AGSMPLPUSH-54]
