### PR TITLE
Adding Docker image to enable running the complete test suite.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM dbevenius/sps-integration
+MAINTAINER Daniel Bevenius <daniel.bevenius@gmail.com>
+
+WORKDIR /home/aerogear-simplepush-server
+
+# Change to the correct repository before committing.
+RUN git clone https://github.com/danbev/aerogear-simplepush-server  /home/aerogear-simplepush-server
+
+# Remove this once the pull request has been tested.
+RUN git checkout -b docker origin/docker
+
+# Run a Maven install when installing the image to avoid this cost 
+# of downloading the internet (all deps).
+RUN mvn install -DskipTests=true
+
+EXPOSE 7777
+
+# startup.sh will start CouchDB and Redis 
+# and the run the integration/functional tests.
+CMD ["/bin/bash", "/startup.sh"]
+

--- a/README.md
+++ b/README.md
@@ -40,3 +40,42 @@ A WildFly/AS7 module for the SimplePush Server.
 
 Please refer to the above modules documentation for more information.
 
+
+## Docker
+You can use [Docker](https://www.docker.io) to build and run SimplePush server. Follow the instructions to
+ [install docker](https://www.docker.io/gettingstarted/).
+
+The Docker [image]() provided contains CouchDB and Redis which enables the functional tests that use these databases
+to be run.
+
+### Build a SimplePush Container
+#### Build using github path
+```docker build -t simplepush github.com/aerogear/aerogear-simplepush-server```
+
+### Build using cloned project
+```docker build -t simplepush .```
+
+### Run integration tests
+`docker run -it simplepush`
+
+### Run standalone Netty server
+```docker run -p 7777:7777 -w /home/aerogear-simplepush-server/server-netty -it simplepush mvn exec:java```
+
+### Manually running test
+You may want to trigger test using a different branch, perhaps to run the integration tests against
+that code base. This can be done by starting the image using a shell:
+
+```docker run -it simplepush /bin/bash```
+
+You'll need to start the databases (currently CouchDB and Redis):
+
+```/startdbs.sh```
+
+Now, you can clone your fork and checkout a branch. To run all tests including the integration/functional tests:
+
+```mvn install -Pcouchdb,redis```
+
+#### Port forwarding for Mac OS X
+You'll need to configure your VirtualBox to support port forwarding for port ```7777```:
+
+```VBoxManage modifyvm "boot2docker-vm" --natpf1 "guestnginx,tcp,,7777,,7777"```

--- a/server-netty/src/main/resources/simplepush-config.json
+++ b/server-netty/src/main/resources/simplepush-config.json
@@ -1,6 +1,7 @@
 {
-    "host": "localhost",
+    "host": "0.0.0.0",
     "port": 7777,
+    "endpoint-host": "localhost",
     "password": "ChangeMe!!!!",
     "datastore": { "in-memory": {} }
 }

--- a/server-netty/src/test/java/org/jboss/aerogear/simplepush/server/netty/standalone/ConfigReaderTest.java
+++ b/server-netty/src/test/java/org/jboss/aerogear/simplepush/server/netty/standalone/ConfigReaderTest.java
@@ -168,7 +168,7 @@ public class ConfigReaderTest {
     @Test
     public void sampleConfig() {
         final StandaloneConfig config = ConfigReader.parse(ConfigReaderTest.class.getResourceAsStream("/simplepush-config.json"));
-        assertThat(config.simplePushServerConfig().host(), equalTo("localhost"));
+        assertThat(config.simplePushServerConfig().host(), equalTo("0.0.0.0"));
         assertThat(config.simplePushServerConfig().port(), is(7777));
         assertThat(config.simplePushServerConfig().password(), is(notNullValue()));
         assertThat(config.dataStore(), is(instanceOf(InMemoryDataStore.class)));


### PR DESCRIPTION
Motivation:
Currently running all the tests in the project requires a local
installation of CouchDB and Redis. Providing a Docker image with these
databases pre-installed might help others to also run the complete test
suite.
