### PR TITLE
Improving logging for server.

### DIFF
--- a/server-netty/pom.xml
+++ b/server-netty/pom.xml
@@ -135,7 +135,6 @@
                 <version>${version.exec-maven-plugin}</version>
                 <configuration>
                     <mainClass>org.jboss.aerogear.simplepush.server.netty.standalone.NettySockJSServer</mainClass>
-                    <classpathScope>test</classpathScope>
                     <arguments>
                         <argument>/simplepush-config.json</argument>
                     </arguments>

--- a/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/NotificationHandler.java
+++ b/server-netty/src/main/java/org/jboss/aerogear/simplepush/server/netty/NotificationHandler.java
@@ -126,6 +126,10 @@ public class NotificationHandler extends SimpleChannelInboundHandler<Object> {
                 final Notification notification = simplePushServer.handleNotification(endpoint, payload.toString(UTF_8));
                 final String uaid = notification.uaid();
                 final SockJsSessionContext session = userAgents.get(uaid).context();
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Sending notification for UAID [ " + notification.uaid() + "] " +
+                            toJson(new NotificationMessageImpl(notification.ack())));
+                }
                 session.send(toJson(new NotificationMessageImpl(notification.ack())));
                 userAgents.updateAccessedTime(uaid);
             } catch (final ChannelNotFoundException e) {

--- a/server-netty/src/main/resources/simplelogger.properties
+++ b/server-netty/src/main/resources/simplelogger.properties
@@ -1,2 +1,2 @@
-org.slf4j.simpleLogger.log.org.jboss.aerogear.simplepush.server.netty.standalone=DEBUG
-org.slf4j.simpleLogger.defaultLogLevel=ERROR
+org.slf4j.simpleLogger.log.org.jboss.aerogear.simplepush.server=debug
+org.slf4j.simpleLogger.defaultLogLevel=info

--- a/server-netty/src/test/resources/simplelogger.properties
+++ b/server-netty/src/test/resources/simplelogger.properties
@@ -1,2 +1,2 @@
-org.slf4j.simpleLogger.log.org.jboss.aerogear.simplepush.server.netty.standalone=debug
-org.slf4j.simpleLogger.defaultLogLevel=ERROR
+org.slf4j.simpleLogger.log.org.jboss.aerogear.simplepush.server=error
+org.slf4j.simpleLogger.defaultLogLevel=error


### PR DESCRIPTION
Motivation:
Currently, even when debug log level is set there are now logs showing
notifications being sent to connected clients. This would improve
testing to see that messages are reaching the server.

Modifications:
Logging has been added to the NotifiacationHandler and will log the
UserAgent ID as well as the updates for the notification.

By default logging is turned on for when running the server using but
can be turned off by updating
src/main/resources/simplelogger.properties.

Logging for tests are turned off by default to avoid extra noice but can
be turned on by updating:
src/test/resources/simplelogger.properties

[https://issues.jboss.org/browse/AGSMPLPUSH-65]
