### PR TITLE
Removing non-exising Netty SockJS dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,11 +157,6 @@
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-sockjs</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.ektorp</groupId>
                 <artifactId>org.ektorp</artifactId>
                 <version>${ektorp.version}</version>


### PR DESCRIPTION
This dependency will be used later when the SockJS PR is merged into
upstream Netty [1]

[1] https://github.com/netty/netty/pull/1615
