### PR TITLE
Update SockJS CDN URL as is being retired.

### DIFF
--- a/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/SockJsConfig.java
+++ b/netty-codec-sockjs/src/main/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/SockJsConfig.java
@@ -135,7 +135,7 @@ public final class SockJsConfig {
     /**
      * The url to the sock-js-<version>.json. This is used by the 'prefix/iframe' protocol and
      * the url is replaced in the script returned to the client. This allows for configuring
-     * the version of sockjs used. By default it is 'http://cdn.sockjs.org/sockjs-0.3.4.min.js'.
+     * the version of sockjs used. By default it is 'http://cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js'.
      *
      * @return {@code String} the url to the sockjs version to be used.
      */
@@ -233,7 +233,7 @@ public final class SockJsConfig {
         private long webSocketHeartbeatInterval = -1;
         private final Set<String> webSocketProtocols = new HashSet<String>();
         private boolean cookiesNeeded;
-        private String sockJsUrl = "http://cdn.sockjs.org/sockjs-0.3.4.min.js" ;
+        private String sockJsUrl = "http://cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js";
         private long sessionTimeout = 5000;
         private long heartbeatInterval = 25000;
         private int maxStreamingBytesSize = 128 * 1024;
@@ -296,7 +296,7 @@ public final class SockJsConfig {
         /**
          * The url to the sock-js-<version>.json. This is used by the 'prefix/iframe' protocol and
          * the url is replaced in the script returned to the client. This allows for configuring
-         * the version of sockjs used. By default it is 'http://cdn.sockjs.org/sockjs-0.3.4.min.js'.
+         * the version of sockjs used. By default it is 'http://cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js'.
          *
          * @param sockJsUrl the url to the sockjs version to be used.
          */

--- a/netty-codec-sockjs/src/test/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/IframeTest.java
+++ b/netty-codec-sockjs/src/test/java/org/jboss/aerogear/io/netty/handler/codec/sockjs/handler/IframeTest.java
@@ -106,7 +106,7 @@ public class IframeTest {
     }
 
     private static SockJsConfig config() {
-        return SockJsConfig.withPrefix("/simplepush").sockJsUrl("http://cdn.sockjs.org/sockjs-0.3.4.min.js").build();
+        return SockJsConfig.withPrefix("/simplepush").sockJsUrl("http://cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js").build();
     }
 
     private static HttpRequest createHttpRequest(final String path) {

--- a/server-netty/README.md
+++ b/server-netty/README.md
@@ -46,7 +46,7 @@ Example configuration:
         "notifier-max-threads": "8",
         "sockjs-prefix": "/simplepush",
         "sockjs-cookies-needed": "true",
-        "sockjs-url": "http://cdn.sockjs.org/sockjs-0.3.4.min.js",
+        "sockjs-url": "http://cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js",
         "sockjs-session-timeout": "5000",
         "sockjs-heartbeat-interval": 25000,
         "sockjs-max-streaming-bytes-size": 65356,
@@ -104,7 +104,7 @@ This is used by some load balancers to enable session stickyness. Default is tru
 #### sockjs-url
 The url to the sock-js-<version>.json. This is used by the 'iframe' protocol and the url is replaced in the script 
 returned to the client. This allows for configuring the version of sockjs used.  
-Default is _http://cdn.sockjs.org/sockjs-0.3.4.min.js_.
+Default is _http://cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js_.
 
 #### sockjs-session-timeout
 A timeout for inactive sessions. Default is 5000 ms. 

--- a/server-netty/src/main/resources/simplepush-couchdb-config.json
+++ b/server-netty/src/main/resources/simplepush-couchdb-config.json
@@ -10,7 +10,7 @@
     "ack-interval": "60000",
     "sockjs-prefix": "/simplepush",
     "sockjs-cookies-needed": "true",
-    "sockjs-url": "http://cdn.sockjs.org/sockjs-0.3.4.min.js",
+    "sockjs-url": "http://cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js",
     "sockjs-session-timeout": "5000",
     "sockjs-heartbeat-interval": 25000,
     "sockjs-max-streaming-bytes-size": 65356,

--- a/server-netty/src/main/resources/simplepush-inmem-config.json
+++ b/server-netty/src/main/resources/simplepush-inmem-config.json
@@ -10,7 +10,7 @@
     "ack-interval": "60000",
     "sockjs-prefix": "/simplepush",
     "sockjs-cookies-needed": "true",
-    "sockjs-url": "http://cdn.sockjs.org/sockjs-0.3.4.min.js",
+    "sockjs-url": "http://cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js",
     "sockjs-session-timeout": "5000",
     "sockjs-heartbeat-interval": 25000,
     "sockjs-max-streaming-bytes-size": 65356,

--- a/server-netty/src/main/resources/simplepush-jpa-config.json
+++ b/server-netty/src/main/resources/simplepush-jpa-config.json
@@ -10,7 +10,7 @@
     "ack-interval": "60000",
     "sockjs-prefix": "/simplepush",
     "sockjs-cookies-needed": "true",
-    "sockjs-url": "http://cdn.sockjs.org/sockjs-0.3.4.min.js",
+    "sockjs-url": "http://cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js",
     "sockjs-session-timeout": "5000",
     "sockjs-heartbeat-interval": 25000,
     "sockjs-max-streaming-bytes-size": 65356,

--- a/server-netty/src/main/resources/simplepush-redis-config.json
+++ b/server-netty/src/main/resources/simplepush-redis-config.json
@@ -10,7 +10,7 @@
     "ack-interval": "60000",
     "sockjs-prefix": "/simplepush",
     "sockjs-cookies-needed": "true",
-    "sockjs-url": "http://cdn.sockjs.org/sockjs-0.3.4.min.js",
+    "sockjs-url": "http://cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js",
     "sockjs-session-timeout": "5000",
     "sockjs-heartbeat-interval": 25000,
     "sockjs-max-streaming-bytes-size": 65356,

--- a/wildfly-module/README.md
+++ b/wildfly-module/README.md
@@ -69,7 +69,7 @@ This section goes through all of the configuration options available.
             notifier-max-threads="8"
             sockjs-prefix="simplepush"
             sockjs-cookies-needed="true"
-            sockjs-url="http://cdn.sockjs.org/sockjs-0.3.4.min.js"
+            sockjs-url="http://cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js"
             sockjs-session-timeout="5000"
             sockjs-heartbeat-interval="25000"
             sockjs-max-streaming-bytes-size="131072"
@@ -138,7 +138,7 @@ This is used by some load balancers to enable session stickyness. Default is tru
 #### sockjs-url
 The url to the sock-js-<version>.json. This is used by the 'iframe' protocol and the url is replaced in the script 
 returned to the client. This allows for configuring the version of sockjs used.  
-Default is _http://cdn.sockjs.org/sockjs-0.3.4.min.js_.
+Default is _http://cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js_.
 
 #### sockjs-session-timeout
 A timeout for inactive sessions. Default is 5000 ms. 


### PR DESCRIPTION
Motivation:
The SockJS CDN will retire on 1 Dec 2014 [1] and we need up update our
netty-codec-sockjs and our documentation to reflect this.

JIRA: https://issues.jboss.org/browse/AGSMPLPUSH-68

[1] https://github.com/sockjs/sockjs-client/issues/198

This can be tested using the following steps. 
1. `mvn clean install`
2. `cd server-netty`
3. `mvn exec:java`
4. `curl -i http://localhost:7777/simplepush/iframe.html`
The response from the above curl command should be something similar to:

``` shell
HTTP/1.1 200 OK
Content-Type: text/html; charset=UTF-8
Cache-Control: max-age=31536000, public
Expires: Sat, 24 Oct 2015 09:08:17 CEST
ETag: "2b50593460aa254330f5fad271aba653"
Content-Length: 489
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true

<!DOCTYPE html>
<html>
<head>
  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
  <script>
    document.domain = document.domain;
    _sockjs_onload = function(){SockJS.bootstrap_iframe();};
  </script>
  <script src="http://cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js"></script>
</head>
<body>
  <h2>Don't panic!</h2>
  <p>This is a SockJS hidden iframe. It's used for cross domain magic.</p>
</body>
</html>
```

The `src` of the script should have been changed from `http://cdn.sockjs.org/sockjs-0.3.4.min.js` to `http://cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js`.

This PR is targeted at [master](https://github.com/aerogear/aerogear-simplepush-server/tree/master) and the [0.12.x](https://github.com/aerogear/aerogear-simplepush-server/tree/0.12.x) branches.
